### PR TITLE
Token Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ ChemistryCafe is a web application built with React, Vite, and TypeScript. The a
 
 ## Getting Started
 
+### Backend Environment Variables
+
+The backend of Chemistry Cafe requires certain secrets that cannot be stored in version control. These secrets are stored in environment variables that are either on the machine or loaded on runtime. Before running the application, make sure to define these variables ahead of time.
+
+To define required environment variables, a `.env` file should be created with the following schema:
+
+```py
+# Required
+GOOGLE_CLIENT_ID=<client_id>
+GOOGLE_CLIENT_SECRET=<client_secret>
+MYSQL_USER=chemistrycafedev
+MYSQL_PASSWORD=chemistrycafe
+MYSQL_DATABASE=chemistry_db
+
+# Optional with defaults
+MYSQL_SERVER=localhost
+MYSQL_PORT=3306
+```
+
+In order to use Google Authentication, a Google Cloud OAuth 2.0 project must be used with a `client id` and `client secret`. When creating the project, `http://localhost:8080/signin-google` should be added to the list of "Authorized redirect URIs" for testing.
+
+**Note:**
+
+- When running locally, the `.env` file must be in the `/backend` directory. 
+- When running with docker, the `.env` file can either be in the root directory *or* `/backend`. If it is in another directory, simply use `docker compose --env-file <path/to/.env> up` instead of the default.  
+
 ### Running Chemistry Cafe with Docker Compose
 
 You must have [Docker Desktop](https://www.docker.com/get-started) installed and running.
@@ -47,7 +73,6 @@ To view logs for all services:
 ```
 docker compose logs -f 
 ```
-
 
 **Note:** To view changes, you must run the docker compose down and then run the project again.
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -6,6 +6,7 @@
 !ChemistryCafeAPI.csproj
 !ChemistryCafeAPI.http
 !Citation.cff
+!client_secrets.json
 !Controllers
 !LICENSE
 !Models

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -18,3 +18,4 @@
 !appsettings.Development.json
 !appsettings.Production.json
 !appsettings.json
+!.env

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,6 +38,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+app/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,6 +6,10 @@
 # dotenv files
 .env
 
+# OAuth Credentials
+client_secrets.json
+
+
 # User-specific files
 *.rsuser
 *.suo

--- a/backend/ChemistryCafeAPI.csproj
+++ b/backend/ChemistryCafeAPI.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="17.11.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
@@ -48,8 +49,7 @@
     <PackageReference Include="MySqlConnector.DependencyInjection" Version="2.3.5" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage"
-                      Version="17.10.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.10.1" />
   </ItemGroup>
 
 </Project>

--- a/backend/ChemistryCafeAPI.csproj
+++ b/backend/ChemistryCafeAPI.csproj
@@ -26,6 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.13" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.4" />

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Protocols.Configuration;
 
 namespace Chemistry_Cafe_API.Controllers
 {
@@ -14,9 +15,11 @@ namespace Chemistry_Cafe_API.Controllers
     public class GoogleOAuthController : Controller
     {
         private readonly GoogleOAuthService _googleOAuthService;
-        public GoogleOAuthController(GoogleOAuthService googleOAuthService)
+        private readonly IConfiguration _configuration;
+        public GoogleOAuthController(IConfiguration configuration, GoogleOAuthService googleOAuthService)
         {
             _googleOAuthService = googleOAuthService;
+            _configuration = configuration;
         }
 
         /// <summary>
@@ -49,7 +52,8 @@ namespace Chemistry_Cafe_API.Controllers
             }
 
             await HttpContext.SignInAsync("Application", claimsIdentity);
-            return Redirect("/swagger");
+            var redirectUrl = (_configuration["FrontendHost"] ?? throw new InvalidConfigurationException("")) + "/LoggedIn";
+            return Redirect(redirectUrl);
         }
 
         /// <summary>
@@ -73,7 +77,8 @@ namespace Chemistry_Cafe_API.Controllers
                 }
             }
 
-            return Redirect("/swagger");
+            var redirectUrl = _configuration["FrontendHost"] ?? throw new InvalidConfigurationException("");
+            return Redirect(redirectUrl);
         }
     }
 }

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chemistry_Cafe_API.Controllers
+{
+    /// <summary>
+    /// Adapted from: https://blog.rashik.com.np/adding-google-authentication-in-net-core-application-without-identity/
+    /// 
+    /// Redirects user to a google login page
+    /// </summary>
+    [Route("/auth/google")]
+    public class GoogleOAuthController : Controller
+    {
+        [HttpGet("login")]
+        public IActionResult LoginRedirect()
+        {
+            AuthenticationProperties authProperties = new AuthenticationProperties { RedirectUri = "/auth/google/authenticate" };
+            return new ChallengeResult(GoogleDefaults.AuthenticationScheme, authProperties);
+        }
+
+        [HttpGet("authenticate")]
+        public async Task<IActionResult> GoogleResponse()
+        {
+            AuthenticateResult result = await HttpContext.AuthenticateAsync("External");
+
+            if (!result.Succeeded)
+            {
+                return BadRequest("Google OAuth Http Response did not succeed");
+            }
+
+            var identityList = result.Principal.Identities.ToList();
+            if (result.Principal != null && identityList.Count > 0)
+            {
+                var identity = identityList[0];
+                if (identity.AuthenticationType != null && identity.AuthenticationType.ToLower().Equals("google"))
+                {
+                    var googleUserId = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
+                    Console.WriteLine("HIHHIIHIHIHIHIHIHHHHHHHHHHHHHHHHHHHHHHH");
+                    Console.WriteLine(googleUserId.Value);
+                    var claimsIdentity = new ClaimsIdentity("Application");
+                    var nameIdClaim = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
+                    var emailClaim = result.Principal.FindFirst(ClaimTypes.Email);
+
+                    if (nameIdClaim != null && emailClaim != null && googleUserId != null)
+                    {
+                        claimsIdentity.AddClaim(nameIdClaim);
+                        claimsIdentity.AddClaim(emailClaim);
+                        claimsIdentity.AddClaim(googleUserId);
+                    }
+                    else
+                    {
+                        return BadRequest("Invalid Claims");
+                    }
+                    await HttpContext.SignInAsync("Application", new ClaimsPrincipal(claimsIdentity));
+                    return Redirect("/swagger");
+                }
+                else
+                {
+                    return BadRequest("Principal or Identity is null");
+                }
+            }
+
+            return Redirect("/swagger");
+        }
+    }
+}

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -59,7 +59,6 @@ namespace Chemistry_Cafe_API.Controllers
         /// <summary>
         /// Removes all authentication cookies and signs a user out of the backend application
         /// </summary>
-        [Authorize]
         [HttpGet("logout")]
         public async Task<IActionResult> Logout()
         {

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -60,8 +60,19 @@ namespace Chemistry_Cafe_API.Controllers
         /// Removes all authentication cookies and signs a user out of the backend application
         /// </summary>
         [HttpGet("logout")]
-        public async Task<IActionResult> Logout()
+        public async Task<IActionResult> Logout(string? returnUrl)
         {
+            string frontendHost = _configuration["FrontendHost"] ?? throw new InvalidConfigurationException("'FrontendHost' key not set in appsettings");
+            // Ensure the redirect url is 
+            if (returnUrl == null || returnUrl.Equals(""))
+            {
+                returnUrl = frontendHost;
+            }
+            else if (!Url.IsLocalUrl(returnUrl) && !returnUrl.StartsWith(frontendHost))
+            {
+                return BadRequest("Invalid returnUrl argument. Must be within application scope.");
+            }
+
             await HttpContext.SignOutAsync("Application");
 
             var request = HttpContext.Request;
@@ -77,10 +88,9 @@ namespace Chemistry_Cafe_API.Controllers
                 }
             }
 
-            string redirectUrl = _configuration["FrontendHost"] ?? throw new InvalidConfigurationException("'FrontendHost' key not set in appsettings");
-            return Redirect(redirectUrl);
+            return Redirect(returnUrl);
         }
-        
+
         [HttpGet("whoami")]
         public UserClaims GetUserClaims()
         {

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Chemistry_Cafe_API.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authorization;
@@ -79,6 +80,24 @@ namespace Chemistry_Cafe_API.Controllers
 
             var redirectUrl = _configuration["FrontendHost"] ?? throw new InvalidConfigurationException("");
             return Redirect(redirectUrl);
+        }
+
+        [Authorize]
+        [HttpGet("whoami")]
+        public UserClaims GetUserClaims()
+        {
+            ClaimsIdentity? claimsIdentity = HttpContext.User.Identity as ClaimsIdentity;
+            if (claimsIdentity == null)
+            {
+                return new UserClaims { ValidClaims = false };
+            }
+
+            return new UserClaims
+            {
+                ValidClaims = true,
+                NameIdentifier = claimsIdentity.FindFirst(ClaimTypes.NameIdentifier)?.Value,
+                EmailClaim = claimsIdentity.FindFirst(ClaimTypes.Email)?.Value
+            };
         }
     }
 }

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -91,6 +91,9 @@ namespace Chemistry_Cafe_API.Controllers
             return Redirect(returnUrl);
         }
 
+        /// <summary>
+        /// Gives the user information on themselves
+        /// </summary>
         [HttpGet("whoami")]
         public UserClaims GetUserClaims()
         {

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -37,8 +37,6 @@ namespace Chemistry_Cafe_API.Controllers
                 if (identity.AuthenticationType != null && identity.AuthenticationType.ToLower().Equals("google"))
                 {
                     var googleUserId = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
-                    Console.WriteLine("HIHHIIHIHIHIHIHIHHHHHHHHHHHHHHHHHHHHHHH");
-                    Console.WriteLine(googleUserId.Value);
                     var claimsIdentity = new ClaimsIdentity("Application");
                     var nameIdClaim = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
                     var emailClaim = result.Principal.FindFirst(ClaimTypes.Email);

--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -6,13 +6,17 @@ using Microsoft.AspNetCore.Mvc;
 namespace Chemistry_Cafe_API.Controllers
 {
     /// <summary>
-    /// Adapted from: https://blog.rashik.com.np/adding-google-authentication-in-net-core-application-without-identity/
-    /// 
-    /// Redirects user to a google login page
+    /// Controls routes related to Google OAuth 2.0 authentication
     /// </summary>
     [Route("/auth/google")]
     public class GoogleOAuthController : Controller
     {
+        private readonly GoogleOAuthService _googleOAuthService;
+        public GoogleOAuthController(GoogleOAuthService googleOAuthService)
+        {
+            _googleOAuthService = googleOAuthService;
+        }
+
         [HttpGet("login")]
         public IActionResult LoginRedirect()
         {
@@ -24,42 +28,18 @@ namespace Chemistry_Cafe_API.Controllers
         public async Task<IActionResult> GoogleResponse()
         {
             AuthenticateResult result = await HttpContext.AuthenticateAsync("External");
-
             if (!result.Succeeded)
             {
                 return BadRequest("Google OAuth Http Response did not succeed");
             }
 
-            var identityList = result.Principal.Identities.ToList();
-            if (result.Principal != null && identityList.Count > 0)
+            var claimsIdentity = _googleOAuthService.GetUserClaims(result);
+            if (claimsIdentity == null)
             {
-                var identity = identityList[0];
-                if (identity.AuthenticationType != null && identity.AuthenticationType.ToLower().Equals("google"))
-                {
-                    var googleUserId = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
-                    var claimsIdentity = new ClaimsIdentity("Application");
-                    var nameIdClaim = result.Principal.FindFirst(ClaimTypes.NameIdentifier);
-                    var emailClaim = result.Principal.FindFirst(ClaimTypes.Email);
-
-                    if (nameIdClaim != null && emailClaim != null && googleUserId != null)
-                    {
-                        claimsIdentity.AddClaim(nameIdClaim);
-                        claimsIdentity.AddClaim(emailClaim);
-                        claimsIdentity.AddClaim(googleUserId);
-                    }
-                    else
-                    {
-                        return BadRequest("Invalid Claims");
-                    }
-                    await HttpContext.SignInAsync("Application", new ClaimsPrincipal(claimsIdentity));
-                    return Redirect("/swagger");
-                }
-                else
-                {
-                    return BadRequest("Principal or Identity is null");
-                }
+                return BadRequest("Invalid Credentials Passed");
             }
 
+            await HttpContext.SignInAsync("Application", claimsIdentity);
             return Redirect("/swagger");
         }
     }

--- a/backend/Models/UserClaims.cs
+++ b/backend/Models/UserClaims.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Chemistry_Cafe_API.Models
@@ -9,10 +8,6 @@ namespace Chemistry_Cafe_API.Models
     /// </summary>
     public partial class UserClaims
     {
-        [Required]
-        [JsonPropertyName("validClaims")]
-        public bool ValidClaims { get; set; }
-
         [JsonPropertyName("nameId")]
         public string? NameIdentifier { get; set; }
 

--- a/backend/Models/UserClaims.cs
+++ b/backend/Models/UserClaims.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Chemistry_Cafe_API.Models
+{
+    /// <summary>
+    /// Represents a user's authentication claims. 
+    /// These are set in the user's cookies when the user logs in.
+    /// </summary>
+    public partial class UserClaims
+    {
+        [Required]
+        [JsonPropertyName("validClaims")]
+        public bool ValidClaims { get; set; }
+
+        [JsonPropertyName("nameId")]
+        public string? NameIdentifier { get; set; }
+
+        [JsonPropertyName("email")]
+        public string? EmailClaim { get; set; }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -59,18 +59,20 @@ builder.Services.AddMySqlDataSource(connectionString);
 
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("DevelopmentCorsPolicy", builder =>
+    options.AddPolicy("DevelopmentCorsPolicy", policy =>
     {
-        builder.WithOrigins("http://localhost:5173")
+        policy.WithOrigins("http://localhost:5173")
                .AllowAnyMethod()
-               .AllowAnyHeader();
+               .AllowAnyHeader()
+               .AllowCredentials();
     });
 
-    options.AddPolicy("ProductionCorsPolicy", builder =>
+    options.AddPolicy("ProductionCorsPolicy", policy =>
     {
-        builder.WithOrigins("https://cafe-deux-devel.acom.ucar.edu")
+        policy.WithOrigins("https://cafe-deux-devel.acom.ucar.edu")
                .AllowAnyMethod()
-               .AllowAnyHeader();
+               .AllowAnyHeader()
+               .AllowCredentials();
     });
 });
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -2,6 +2,7 @@ using Chemistry_Cafe_API.Services;
 using MySqlConnector;
 using Microsoft.AspNetCore.HttpOverrides;
 using Chemistry_Cafe_API.Controllers;
+using dotenv.net;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,6 +10,9 @@ if (!builder.Environment.IsDevelopment())
 {
     builder.WebHost.UseUrls("http://0.0.0.0:5000");
 }
+
+// Configure Environment
+DotEnv.Load();
 
 // Add services to the container.
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,6 +1,7 @@
 using Chemistry_Cafe_API.Services;
 using MySqlConnector;
 using Microsoft.AspNetCore.HttpOverrides;
+using Chemistry_Cafe_API.Controllers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,6 +24,7 @@ builder.Services.AddScoped<InitialConditionSpeciesService>();
 builder.Services.AddScoped<OpenAtmosService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<PropertyService>();
+builder.Services.AddScoped<GoogleOAuthService>();
 
 string googleClientId = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") ?? throw new InvalidOperationException("GOOGLE_CLIENT_ID environment variable is missing.");
 string googleClientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") ?? throw new InvalidOperationException("GOOGLE_CLIENT_SECRET environment variable is missing.");

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -23,6 +23,23 @@ builder.Services.AddScoped<InitialConditionSpeciesService>();
 builder.Services.AddScoped<OpenAtmosService>();
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<PropertyService>();
+
+string googleClientId = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") ?? throw new InvalidOperationException("GOOGLE_CLIENT_ID environment variable is missing.");
+string googleClientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") ?? throw new InvalidOperationException("GOOGLE_CLIENT_SECRET environment variable is missing.");
+
+builder.Services.AddAuthentication((options) =>
+    {
+        options.DefaultScheme = "Application";
+        options.DefaultSignInScheme = "External";
+    })
+    .AddCookie("Application")
+    .AddCookie("External")
+    .AddGoogle((options) =>
+    {
+        options.ClientId = googleClientId;
+        options.ClientSecret = googleClientSecret;
+    });
+
 //builder.Services.AddScoped<TimeService>();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -72,6 +89,7 @@ else
     });
 }
 
+app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 app.Run();

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,6 +6,10 @@ API for the Chemistry Cafe web application found here https://github.com/NCAR/ch
 
 # Getting Started
 
+## Google Cloud
+
+In order to use Google Authentication, a Google Cloud OAuth 2.0 project must be used for testing. When creating the project, `http://localhost:8080/signin-google` should be added to the list of Authorized redirect URIs.
+
 ## Environment Variables
 
 For the backend to connect to the MySQL server, certain environment variables must be specified. The default values can be seen in `docker-compose.yml`. These variables are the following:
@@ -23,7 +27,7 @@ MYSQL_SERVER=localhost
 MYSQL_PORT=3306
 ```
 
-`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found in a google cloud project. 
+`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found in a google cloud project. These variables may be set in a `.env` file in the `/backend` directory or created on the machine itself.
 
 ## Command line
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,14 +11,19 @@ API for the Chemistry Cafe web application found here https://github.com/NCAR/ch
 For the backend to connect to the MySQL server, certain environment variables must be specified. The default values can be seen in `docker-compose.yml`. These variables are the following:
 
 ```py
-MYSQL_SERVER=localhost
+# Required
+GOOGLE_CLIENT_ID=<client_id>
+GOOGLE_CLIENT_SECRET=<client_secret>
 MYSQL_USER=chemistrycafedev
 MYSQL_PASSWORD=chemistrycafe
 MYSQL_DATABASE=chemistry_db
+
+# Optional with defaults
+MYSQL_SERVER=localhost
 MYSQL_PORT=3306
 ```
 
-The only ones that are required are `MYSQL_USER`, `MYSQL_PASSWORD`, and `MYSQL_DATABASE`. `MYSQL_SERVER` defaults to "localhost" and `MYSQL_PORT` defaults to "3306".
+`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found in a google cloud project. 
 
 ## Command line
 

--- a/backend/Services/GoogleOAuthService.cs
+++ b/backend/Services/GoogleOAuthService.cs
@@ -16,7 +16,7 @@ namespace Chemistry_Cafe_API.Controllers
         /// <returns>ClaimsPrincipal object which holds the user's auth informations</returns>
         public ClaimsPrincipal? GetUserClaims(AuthenticateResult authenticateResult)
         {
-            if (authenticateResult == null || authenticateResult.Principal == null)
+            if (authenticateResult.Principal == null)
             {
                 return null;
             }

--- a/backend/Services/GoogleOAuthService.cs
+++ b/backend/Services/GoogleOAuthService.cs
@@ -28,15 +28,13 @@ namespace Chemistry_Cafe_API.Controllers
                 if (identity.AuthenticationType != null && identity.AuthenticationType.ToLower().Equals("google"))
                 {
                     var claimsIdentity = new ClaimsIdentity("Application");
-                    var googleUserId = authenticateResult.Principal.FindFirst(ClaimTypes.NameIdentifier);
-                    var nameIdClaim = authenticateResult.Principal.FindFirst(ClaimTypes.NameIdentifier);
+                    var nameIdClaim = authenticateResult.Principal.FindFirst(ClaimTypes.NameIdentifier); // GUID specified by Google
                     var emailClaim = authenticateResult.Principal.FindFirst(ClaimTypes.Email);
 
-                    if (nameIdClaim != null && emailClaim != null && googleUserId != null)
+                    if (nameIdClaim != null && emailClaim != null)
                     {
                         claimsIdentity.AddClaim(nameIdClaim);
                         claimsIdentity.AddClaim(emailClaim);
-                        claimsIdentity.AddClaim(googleUserId);
                     }
                     else
                     {

--- a/backend/Services/GoogleOAuthService.cs
+++ b/backend/Services/GoogleOAuthService.cs
@@ -1,0 +1,51 @@
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chemistry_Cafe_API.Controllers
+{
+    /// <summary>
+    /// Adapted from: https://blog.rashik.com.np/adding-google-authentication-in-net-core-application-without-identity/
+    /// </summary>
+    public class GoogleOAuthService
+    {
+        public ClaimsPrincipal? GetUserClaims(AuthenticateResult authenticateResult)
+        {
+            if (authenticateResult == null || authenticateResult.Principal == null)
+            {
+                return null;
+            }
+
+            var identityList = authenticateResult.Principal.Identities.ToList();
+            if (authenticateResult.Principal != null && identityList.Count > 0)
+            {
+                var identity = identityList[0];
+                if (identity.AuthenticationType != null && identity.AuthenticationType.ToLower().Equals("google"))
+                {
+                    var claimsIdentity = new ClaimsIdentity("Application");
+                    var googleUserId = authenticateResult.Principal.FindFirst(ClaimTypes.NameIdentifier);
+                    var nameIdClaim = authenticateResult.Principal.FindFirst(ClaimTypes.NameIdentifier);
+                    var emailClaim = authenticateResult.Principal.FindFirst(ClaimTypes.Email);
+
+                    if (nameIdClaim != null && emailClaim != null && googleUserId != null)
+                    {
+                        claimsIdentity.AddClaim(nameIdClaim);
+                        claimsIdentity.AddClaim(emailClaim);
+                        claimsIdentity.AddClaim(googleUserId);
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                    return new ClaimsPrincipal(claimsIdentity);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/backend/Services/GoogleOAuthService.cs
+++ b/backend/Services/GoogleOAuthService.cs
@@ -1,7 +1,6 @@
 
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Chemistry_Cafe_API.Controllers
 {
@@ -10,6 +9,11 @@ namespace Chemistry_Cafe_API.Controllers
     /// </summary>
     public class GoogleOAuthService
     {
+        /// <summary>
+        /// Parses an OAuth challenge result and turns them into a user's claims
+        /// </summary>
+        /// <param name="authenticateResult">Result of Google OAuth Challenge</param>
+        /// <returns>ClaimsPrincipal object which holds the user's auth informations</returns>
         public ClaimsPrincipal? GetUserClaims(AuthenticateResult authenticateResult)
         {
             if (authenticateResult == null || authenticateResult.Principal == null)

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -4,5 +4,6 @@
             "Default": "Debug",
             "Microsoft.AspNetCore": "Debug"
         }
-    }
+    },
+    "FrontendHost": "http://localhost:5173"
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -5,5 +5,6 @@
             "Microsoft.AspNetCore": "Debug"
         }
     },
-    "AllowedHosts": "*"
+    "AllowedHosts": "*",
+    "FrontendHost": "http://localhost:5173"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       - backend # Ensure the backend service starts before frontend
     environment:
       # - ASPNETCORE_ENVIRONMENT=Development
-      - API_URL=http://backend:8080 # This points to the backend service within the Docker network
       # - ASPNETCORE_URLS=http://0.0.0.0:8080
+      - API_URL=http://backend:8080 # This points to the backend service within the Docker network
     networks:
       - app-network
     # test code by britt to enable live updates to frontend with docker
@@ -60,6 +60,8 @@ services:
     environment:
       <<: *db-env
       ASPNETCORE_ENVIRONMENT: Development
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
     networks:
       - app-network
     command: ["dotnet", "watch", "run", "--project", "ChemistryCafeAPI.csproj"] # Command for development

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,2 @@
-VITE_REACT_APP_OAUTH_CLIENT_ID="257697450661-a69l9bv939uuso551n6pcf1gngpv9ql0.apps.googleusercontent.com"
 VITE_BASE_URL=http://localhost:8080/api
+VITE_AUTH_URL=http://localhost:8080/auth

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
-VITE_REACT_APP_OAUTH_CLIENT_ID="257697450661-a69l9bv939uuso551n6pcf1gngpv9ql0.apps.googleusercontent.com"
 VITE_BASE_URL=https://cafe-deux.acom.ucar.edu/api/api
+VITE_AUTH_URL=https://cafe-deux.acom.ucar.edu/api/auth

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,2 +1,2 @@
-VITE_REACT_APP_OAUTH_CLIENT_ID="257697450661-a69l9bv939uuso551n6pcf1gngpv9ql0.apps.googleusercontent.com"
 VITE_BASE_URL=http://localhost:8080/api
+VITE_AUTH_URL=http://localhost:8080/auth

--- a/frontend/src/API/API_GetMethods.tsx
+++ b/frontend/src/API/API_GetMethods.tsx
@@ -11,8 +11,9 @@ import {
   ReactionSpeciesDto,
   InitialConditionSpecies,
   Property,
+  UserClaims,
 } from "./API_Interfaces";
-import { BASE_URL } from "./API_config";
+import { AUTH_URL, BASE_URL } from "./API_config";
 
 // Get all families
 export async function getFamilies(): Promise<Family[]> {
@@ -261,6 +262,25 @@ export async function getUserById(id: string): Promise<User> {
     console.error(`Error fetching user ${id}: ${error.message}`, error);
     throw new Error("Failed to fetch user. Please try again later.");
   }
+}
+
+/**
+ * Gets the currently logged in user
+ */
+export async function getGoogleAuthUser(): Promise<UserClaims | null> {
+  return axios.get<UserClaims>(
+    `${AUTH_URL}/google/whoami`,
+    {
+      maxRedirects: 0,
+      withCredentials: true,
+    })
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error: any) => {
+      console.error(`Error fetching current user: ${error}`);
+      return null;
+    });
 }
 
 export async function getPropertyById(id: string): Promise<Property> {

--- a/frontend/src/API/API_Interfaces.tsx
+++ b/frontend/src/API/API_Interfaces.tsx
@@ -76,6 +76,11 @@ export interface User {
   created_date?: string;
 }
 
+export interface UserClaims {
+  nameId?: string | null;
+  email?: string | null;
+}
+
 export interface UserMechanism {
   id?: string;
   user_id: string;

--- a/frontend/src/API/API_config.tsx
+++ b/frontend/src/API/API_config.tsx
@@ -1,1 +1,2 @@
 export const BASE_URL = import.meta.env.VITE_BASE_URL;
+export const AUTH_URL = import.meta.env.VITE_AUTH_URL;

--- a/frontend/src/components/NavDropDown.tsx
+++ b/frontend/src/components/NavDropDown.tsx
@@ -5,6 +5,7 @@ import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import ListItemButton from "@mui/material/ListItemButton";
 import { useAuth } from "../pages/AuthContext"; // Import useAuth to get the user data
+import { AUTH_URL } from "../API/API_config";
 
 const NavDropDown = () => {
   const navigate = useNavigate();
@@ -16,7 +17,7 @@ const NavDropDown = () => {
   const goFamily = () => navigate("/FamilyPage");
   const goLogOut = () => {
     setUser(null);
-    navigate("/");
+    window.location.href = `${AUTH_URL}/google/logout`;
   };
   const goRoles = () => navigate("/Roles"); // Add navigation to Roles page
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { GoogleOAuthProvider } from "@react-oauth/google";
 import App from "./pages/App";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
@@ -8,17 +7,11 @@ import "./index.css";
 
 const rootElement = document.getElementById("root");
 const root = createRoot(rootElement!);
-const url = import.meta.env.VITE_REACT_APP_OAUTH_CLIENT_ID;
 
 root.render(
   <BrowserRouter>
-    <GoogleOAuthProvider
-      clientId={url}
-      nonce={"F04DAE83-E065-4AB5-904F-C2E5E3B3390C"}
-    >
-      <React.StrictMode>
-        <App />
-      </React.StrictMode>
-    </GoogleOAuthProvider>
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
   </BrowserRouter>,
 );

--- a/frontend/src/pages/AuthContext.tsx
+++ b/frontend/src/pages/AuthContext.tsx
@@ -3,9 +3,10 @@ import {
   useState,
   useContext,
   ReactNode,
-  useEffect,
+  useLayoutEffect,
 } from "react";
 import { User } from "../API/API_Interfaces";
+import { getGoogleAuthUser, getUserByEmail } from "../API/API_GetMethods";
 
 // Define the shape of the AuthContext
 interface AuthContextProps {
@@ -24,14 +25,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     return storedUser ? JSON.parse(storedUser) : null;
   });
 
-  useEffect(() => {
-    // Store user in localStorage whenever it changes
-    if (user) {
-      localStorage.setItem("user", JSON.stringify(user));
-    } else {
-      localStorage.removeItem("user");
+  useLayoutEffect(() => {
+    const getUser = async () => {
+      if (!user) {
+        const authInfo = await getGoogleAuthUser();
+        if (authInfo?.email) {
+          setUser(await getUserByEmail(authInfo?.email));
+        }
+      }
     }
-  }, [user]);
+
+    getUser();
+  }, []);
 
   return (
     <AuthContext.Provider value={{ user, setUser }}>

--- a/frontend/src/pages/logIn.tsx
+++ b/frontend/src/pages/logIn.tsx
@@ -23,7 +23,8 @@ const LogIn: React.FC = () => {
   // Log out function to log the user out of Google and set the profile array to null
   const continueAsGuest = () => {
     setUser(null); // Clear user from AuthContext on logout
-    window.location.href = `${AUTH_URL}/google/logout`;
+    const returnUrl = `${window.location.protocol}//${window.location.host}/loggedIn`;
+    window.location.href = encodeURI(`${AUTH_URL}/google/logout?returnUrl=${returnUrl}`);
   };
 
   return (

--- a/frontend/src/pages/logIn.tsx
+++ b/frontend/src/pages/logIn.tsx
@@ -1,8 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { googleLogout, useGoogleLogin } from "@react-oauth/google";
-import axios from "axios";
 import { useAuth } from "../pages/AuthContext"; // Import the AuthContext
-
 import "../styles/logIn.css";
 import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
@@ -12,92 +9,21 @@ import GoogleIcon from "@mui/icons-material/Google";
 import NoAccountsIcon from "@mui/icons-material/NoAccounts";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
 import { Footer, Header } from "../components/HeaderFooter";
-import { getUserByEmail } from "../API/API_GetMethods";
-import { createUser } from "../API/API_CreateMethods";
+import { AUTH_URL } from "../API/API_config";
 
-interface AuthUser {
-  access_token: string;
-}
 
 const LogIn: React.FC = () => {
   const { setUser, user } = useAuth(); // Get setUser from AuthContext
   const navigate = useNavigate();
 
-  const setUserInformation = async (user: AuthUser) => {
-    if (user) {
-      // Fetch the user profile using the access token
-      axios
-        .get(
-          `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${user.access_token}`,
-          {
-            headers: {
-              Authorization: `Bearer ${user.access_token}`,
-              Accept: "application/json",
-            },
-          },
-        )
-        .then(async (res) => {
-          const profileData = res.data;
-
-          if (!profileData.email) {
-            console.error("Profile data does not contain an email.");
-            alert("Profile data is missing email information.");
-            return;
-          }
-
-          // Check if the user already exists in the database
-          try {
-            const existingUser = await getUserByEmail(profileData.email);
-            if (existingUser) {
-              const contextUser = {
-                id: existingUser.id,
-                username: existingUser.username,
-                email: existingUser.email,
-                role: existingUser.role || "unverified",
-              };
-              setUser(contextUser);
-            } else {
-              const newUser = {
-                username: profileData.name,
-                email: profileData.email,
-                role: "unverified",
-              };
-              const createdUser = await createUser(newUser);
-
-              const contextUser = {
-                id: createdUser.id,
-                username: createdUser.username,
-                email: createdUser.email,
-                role: createdUser.role || "unverified",
-              };
-
-              setUser(createdUser);
-              console.log("Context user ", contextUser);
-            }
-          } catch (error) {
-            console.error("Error checking or creating user:", error);
-            alert("Error checking or creating user" + error);
-          }
-        })
-        .catch((error) => {
-          console.error("Error fetching user profile:", error);
-          alert("Error fetching profile");
-        });
-    }
+  const login = () => {
+    window.location.href = `${AUTH_URL}/google/login`;
   };
-
-  const login = useGoogleLogin({
-    onSuccess: (codeResponse) => {
-      setUserInformation(codeResponse).then(() => navigate("/LoggedIn"));
-    },
-    onError: (error) => console.log("Login Failed:", error),
-  });
 
   // Log out function to log the user out of Google and set the profile array to null
   const continueAsGuest = () => {
-    googleLogout();
     setUser(null); // Clear user from AuthContext on logout
-    navigate("/LoggedIn");
+    window.location.href = `${AUTH_URL}/google/logout`;
   };
 
   return (


### PR DESCRIPTION
This PR contains breaking changes, so please be mindful that there is some extra config that needs to be added for everything to work locally.

## Overview

Before, authentication was completely handled by the frontend where the website obtained the user's google credentials without any intervention from the backend server. This flow has been completely reworked to utilize http-only cookies from the backend. These cookies are only shared with the frontend host.  Testing has yet to be implemented for this flow.

In addition to moving authentication, `.env` file support has been added. Please see the README for more information.

## Related Pull Requests

- closes #93 
- closes #100 

@K20shores Just a heads up, the google cloud project needs `http://localhost:8080/signin-google` in the list of Authorized redirect URIs. In production, I would assume this is `<domain>/api/signin-google`. I tested this with a new project and it was needed to work properly.