### PR TITLE
Frontend Auth Bugs

### DIFF
--- a/backend/Controllers/GoogleOAuthController.cs
+++ b/backend/Controllers/GoogleOAuthController.cs
@@ -29,6 +29,7 @@ namespace Chemistry_Cafe_API.Controllers
         public IActionResult LoginRedirect()
         {
             AuthenticationProperties authProperties = new AuthenticationProperties { RedirectUri = "/auth/google/authenticate" };
+            authProperties.SetParameter("prompt", "select_account");
             return new ChallengeResult(GoogleDefaults.AuthenticationScheme, authProperties);
         }
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -46,6 +46,7 @@ builder.Services.AddAuthentication((options) =>
     {
         options.ClientId = googleClientId;
         options.ClientSecret = googleClientSecret;
+        options.AccessDeniedPath = "/auth/google/login";
     });
 
 //builder.Services.AddScoped<TimeService>();

--- a/frontend/src/API/API_GetMethods.tsx
+++ b/frontend/src/API/API_GetMethods.tsx
@@ -265,21 +265,17 @@ export async function getUserById(id: string): Promise<User> {
 }
 
 /**
- * Gets the currently logged in user
+ * Gets the currently logged in user claims
  */
 export async function getGoogleAuthUser(): Promise<UserClaims | null> {
-  return axios
-    .get<UserClaims>(`${AUTH_URL}/google/whoami`, {
-      maxRedirects: 0,
-      withCredentials: true,
-    })
-    .then((response) => {
-      return response.data;
-    })
-    .catch((error: any) => {
-      console.error(`Error fetching current user: ${error}`);
-      return null;
-    });
+  try {
+    const response = await axios.get<UserClaims>(`${AUTH_URL}/google/whoami`, { withCredentials: true, });
+    return response.data;
+  }
+  catch (error: any) {
+    console.error(`Error fetching current user: ${error}`);
+    return null;
+  }
 }
 
 export async function getPropertyById(id: string): Promise<Property> {

--- a/frontend/src/components/HeaderFooter.tsx
+++ b/frontend/src/components/HeaderFooter.tsx
@@ -48,6 +48,7 @@ export const Header = () => {
     >
       <Button
         aria-label="Open Side-Navigation Menu"
+        id="side-nav-button"
         onClick={toggleDrawer(true)}
       >
         <DensitySmallSharpIcon

--- a/frontend/src/components/HeaderFooter.tsx
+++ b/frontend/src/components/HeaderFooter.tsx
@@ -150,7 +150,7 @@ export const Footer = () => {
           </Typography>
           <br />
           <Typography variant="h6">Credits</Typography>
-          <Typography variant="body1">
+          <Typography variant="body1" component="span">
             <Typography variant="inherit">
               Paul Cyr, Brandon Longuet, Brian Nguyen <br />
               Spring 2024 Capstone Team

--- a/frontend/src/components/HeaderFooter.tsx
+++ b/frontend/src/components/HeaderFooter.tsx
@@ -146,16 +146,30 @@ export const Footer = () => {
           />
           <Typography variant="body1">
             The Chemistry Cafe tool was made possible by the collaboration
-            between NCAR and Texas A&M through the CSCE Capstone program.
+            between NSF NCAR and Texas A&M through the CSCE Capstone program.
           </Typography>
-          <p></p>
+          <br />
           <Typography variant="h6">Credits</Typography>
           <Typography variant="body1">
-            Paul Cyr, Brandon Longuet, Brian Nguyen <br></br> Spring 2024
-            Capstone Team <br></br> <p></p>
-            Britt Schiller, Ore Ogunleye, Nishka Mittal, Josh Hare, Sydney
-            Ferris <br></br> Fall 2024 Capstone Team <br></br> <p></p>
-            Kyle Shores <br></br> Spring 2024 Capstone Sponsor Representative
+            <Typography variant="inherit">
+              Paul Cyr, Brandon Longuet, Brian Nguyen <br />
+              Spring 2024 Capstone Team
+            </Typography>
+            <br />
+            <Typography variant="inherit">
+              Britt Schiller, Ore Ogunleye, Nishka Mittal, Josh Hare, Sydney Ferris <br />
+              Fall 2024 Capstone Team
+            </Typography>
+            <br />
+            <Typography variant="inherit">
+              Jackson Stewart, Kaili Fogle, Robbie Cook, Donato Curvino, James Fontenot <br />
+              Spring 2025 Capstone Team
+            </Typography>
+            <br />
+            <Typography variant="inherit">
+              Kyle Shores <br />
+              Capstone Sponsor Representative
+            </Typography>
           </Typography>
         </Box>
       </Modal>

--- a/frontend/src/components/NavDropDown.tsx
+++ b/frontend/src/components/NavDropDown.tsx
@@ -17,7 +17,8 @@ const NavDropDown = () => {
   const goFamily = () => navigate("/FamilyPage");
   const goLogOut = () => {
     setUser(null);
-    window.location.href = `${AUTH_URL}/google/logout`;
+    localStorage.removeItem("user");
+    window.location.assign(`${AUTH_URL}/google/logout`);
   };
   const goRoles = () => navigate("/Roles"); // Add navigation to Roles page
 

--- a/frontend/src/pages/AuthContext.tsx
+++ b/frontend/src/pages/AuthContext.tsx
@@ -36,7 +36,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
 
     getUser();
-  }, []);
+  }, [user]);
 
   return (
     <AuthContext.Provider value={{ user, setUser }}>

--- a/frontend/src/pages/AuthContext.tsx
+++ b/frontend/src/pages/AuthContext.tsx
@@ -30,7 +30,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       if (!user) {
         const authInfo = await getGoogleAuthUser();
         if (authInfo?.email) {
-          setUser(await getUserByEmail(authInfo?.email));
+          const userInfo = await getUserByEmail(authInfo?.email);
+          setUser(userInfo);
+          localStorage.setItem("user", JSON.stringify(userInfo));
         }
       }
     };

--- a/frontend/src/pages/logIn.tsx
+++ b/frontend/src/pages/logIn.tsx
@@ -16,7 +16,7 @@ const LogIn: React.FC = () => {
   const navigate = useNavigate();
 
   const login = () => {
-    window.location.href = `${AUTH_URL}/google/login`;
+    window.location.assign(`${AUTH_URL}/google/login`);
   };
 
   // Log out function to log the user out of Google and set the profile array to null

--- a/frontend/src/pages/logIn.tsx
+++ b/frontend/src/pages/logIn.tsx
@@ -16,6 +16,7 @@ const LogIn: React.FC = () => {
   const navigate = useNavigate();
 
   const login = () => {
+    localStorage.removeItem("user");
     window.location.assign(`${AUTH_URL}/google/login`);
   };
 

--- a/frontend/src/pages/logIn.tsx
+++ b/frontend/src/pages/logIn.tsx
@@ -21,11 +21,20 @@ const LogIn: React.FC = () => {
 
   // Log out function to log the user out of Google and set the profile array to null
   const continueAsGuest = () => {
-    setUser(null); // Clear user from AuthContext on logout
-    const returnUrl = `${window.location.protocol}//${window.location.host}/loggedIn`;
-    window.location.href = encodeURI(
-      `${AUTH_URL}/google/logout?returnUrl=${returnUrl}`,
-    );
+    if (user || localStorage.getItem("user")) {
+      // Clear user from AuthContext
+      setUser(null);
+      localStorage.removeItem("user");
+
+      const returnUrl = `${window.location.protocol}//${window.location.host}/loggedIn`;
+      const loginUrl = encodeURI(
+        `${AUTH_URL}/google/logout?returnUrl=${returnUrl}`,
+      );
+      window.location.assign(loginUrl);
+    }
+    else {
+      navigate("loggedIn");
+    }
   };
 
   return (

--- a/frontend/src/styles/logIn.css
+++ b/frontend/src/styles/logIn.css
@@ -10,9 +10,11 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   background-color: #1a658f;
-  background-image: url("/src/assets/NCAR_ZoomBG_Blue.jpg");
-  background-size: 100%;
+  background-image: url("/src/assets/NCAR-Waves.png");
+  background-position: center center;
+  background-size: 135%;
   background-repeat: no-repeat;
+  background-blend-mode: overlay;
 }
 
 .information-home {

--- a/frontend/test/logIn.test.tsx
+++ b/frontend/test/logIn.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi, test } from "vitest";
 import {
   render,
   screen,
@@ -16,6 +16,12 @@ import axios, { AxiosHeaders, AxiosResponse } from "axios";
 
 vi.mock("axios");
 
+const mockUserInfo: User = {
+  "role": "admin",
+  "email": "test@email.com",
+  "username": "Test Account",
+}
+
 describe("Unauthenticated LogIn Component", () => {
   const originalLocation = window.location;
 
@@ -24,9 +30,6 @@ describe("Unauthenticated LogIn Component", () => {
       data: {
         nameId: null,
         email: null,
-        id: "1234",
-        username: "Test User",
-        role: "admin",
       } as UserClaims & User,
       status: 200,
       statusText: "OK",
@@ -92,90 +95,94 @@ describe("Unauthenticated LogIn Component", () => {
   });
 });
 
-describe("Authenticated LogIn Component", () => {
-  const originalLocation = window.location;
-  const mockUserInfo: User = {
-    "role": "admin",
-    "email": "test@email.com",
-    "username": "Test Account",
-  }
+describe.each([
+  ["", mockUserInfo],
+  ["with uncached user", null],
+  ["with other cached user", {
+    email: "wronguser@gmail.co.uk",
+    role: "unauthenticated",
+    username: "John Doe"
+  }],
+])
+  ("Authenticated LogIn Component %s", (_, cachedUserInfo) => {
+    const originalLocation = window.location;
 
-  function createMockUserData(): AxiosResponse {
-    return {
-      data: {
-        nameId: "1234567890",
-        email: mockUserInfo.email,
-        id: "1234",
-        username: "Test User",
-        role: "admin",
-      } as UserClaims & User,
-      status: 200,
-      statusText: "OK",
-      headers: {},
-      config: {
-        headers: new AxiosHeaders({ "Content-Type": "text/plain" }),
-      },
-    } as AxiosResponse;
-  }
+    function createMockUserData(): AxiosResponse {
+      return {
+        data: {
+          nameId: "1234567890",
+          email: mockUserInfo.email,
+          id: "1234",
+          username: mockUserInfo.username,
+          role: mockUserInfo.role,
+        } as UserClaims & User,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {
+          headers: new AxiosHeaders({ "Content-Type": "text/plain" }),
+        },
+      } as AxiosResponse;
+    }
 
-  beforeEach(async () => {
-    vi.spyOn(axios, "get").mockResolvedValue(createMockUserData());
-    window.location = { ...originalLocation, assign: vi.fn((_: string | URL) => { }) };
+    beforeEach(async () => {
+      vi.spyOn(axios, "get").mockResolvedValue(createMockUserData());
+      window.location = { ...originalLocation, assign: vi.fn((_: string | URL) => { }) };
+      localStorage.setItem("user", JSON.stringify(cachedUserInfo));
+      render(
+        <AuthProvider>
+          <MemoryRouter initialEntries={['/', '/loggedIn']}>
+            <LogIn />
+          </MemoryRouter>
+        </AuthProvider>
+      );
 
-    localStorage.setItem("user", JSON.stringify(mockUserInfo));
-    render(
-      <AuthProvider>
-        <MemoryRouter initialEntries={['/', '/loggedIn']}>
-          <LogIn />
-        </MemoryRouter>
-      </AuthProvider>
-    );
+      await act(() => axios.get); // Allows the initial useLayoutEffect to fire
+    });
 
-    await act(() => axios.get); // Allows the initial useLayoutEffect to fire
+    afterEach(() => {
+      cleanup();
+      window.location = originalLocation;
+      localStorage.clear();
+    });
+
+    it("shows different buttons when logged in", () => {
+      expect(screen.getByText(`Continue as ${mockUserInfo.username}`)).toBeTruthy();
+      expect(screen.getByText("Switch Account")).toBeTruthy();
+      expect(screen.getByText("Continue as Guest")).toBeTruthy();
+    });
+
+    it("navigates to the backend when switching accounts", () => {
+      const loginButton = screen.getByText("Switch Account");
+      expect(loginButton).toBeTruthy();
+      fireEvent.click(loginButton);
+      expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/login endpoint
+    });
+
+    it("navigates to the backend when continuing as a guest", () => {
+      const guestButton = screen.getByText("Continue as Guest");
+      expect(guestButton).toBeTruthy();
+      fireEvent.click(guestButton);
+      expect(window.location.assign).toHaveBeenCalledOnce();
+    });
+
+    it("removes user from local storage when logging out", () => {
+      expect(document.getElementById("side-nav-button")).toBeTruthy();
+      expect(localStorage.getItem("user")).toBeTruthy();
+
+      // Open side nav
+      const hamburgerMenu: HTMLElement = document.getElementById("side-nav-button")!;
+      fireEvent.click(hamburgerMenu);
+
+      // Click logout button
+      const logoutButton = screen.getByText("Log Out");
+      fireEvent.click(logoutButton);
+
+      expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/logout endpoint
+      expect(localStorage.getItem("user")).toBeFalsy();
+    });
   });
 
-  afterEach(() => {
-    cleanup();
-    window.location = originalLocation;
-    localStorage.clear();
-  });
-
-  it("shows different buttons when logged in", () => {
-    expect(screen.getByText(`Continue as ${mockUserInfo.username}`)).toBeTruthy();
-    expect(screen.getByText("Switch Account")).toBeTruthy();
-    expect(screen.getByText("Continue as Guest")).toBeTruthy();
-  });
-
-  it("navigates to the backend when switching accounts", () => {
-    const loginButton = screen.getByText("Switch Account");
-    expect(loginButton).toBeTruthy();
-    fireEvent.click(loginButton);
-    expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/login endpoint
-  });
-
-  it("navigates to the backend when continuing as a guest", () => {
-    const guestButton = screen.getByText("Continue as Guest");
-    expect(guestButton).toBeTruthy();
-    fireEvent.click(guestButton);
-    expect(window.location.assign).toHaveBeenCalledOnce();
-  });
-
-  it("removes user from local storage when logging out", () => {
-    expect(document.getElementById("side-nav-button")).toBeTruthy();
-    expect(localStorage.getItem("user")).toBeTruthy();
-
-    // Open side nav
-    const hamburgerMenu: HTMLElement = document.getElementById("side-nav-button")!;
-    fireEvent.click(hamburgerMenu);
-
-    // Click logout button
-    const logoutButton = screen.getByText("Log Out");
-    fireEvent.click(logoutButton);
-
-    expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/logout endpoint
-    expect(localStorage.getItem("user")).toBeFalsy();
-  });
-});
 
 describe("Sanity Check Tests", () => {
   it("should always pass test 1", () => {

--- a/frontend/test/logIn.test.tsx
+++ b/frontend/test/logIn.test.tsx
@@ -59,6 +59,12 @@ describe("Unauthenticated LogIn Component", () => {
     fireEvent.click(loginButton);
     expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/login endpoint
   });
+
+  it("navigates when continuing as a guest", () => {
+    const loginButton = screen.getByText("Continue as Guest");
+    expect(loginButton).toBeTruthy();
+    fireEvent.click(loginButton);
+  });
 });
 
 describe("Authenticated LogIn Component", () => {

--- a/frontend/test/logIn.test.tsx
+++ b/frontend/test/logIn.test.tsx
@@ -57,7 +57,7 @@ describe("Unauthenticated LogIn Component", () => {
     const loginButton = screen.getByText("Sign in");
     expect(loginButton).toBeTruthy();
     fireEvent.click(loginButton);
-    expect(window.location.assign).toHaveBeenCalledOnce();
+    expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/login endpoint
   });
 });
 
@@ -99,7 +99,7 @@ describe("Authenticated LogIn Component", () => {
     const loginButton = screen.getByText("Switch Account");
     expect(loginButton).toBeTruthy();
     fireEvent.click(loginButton);
-    expect(window.location.assign).toHaveBeenCalledOnce();
+    expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/login endpoint
   });
 
   it("navigates to the backend when continuing as a guest", () => {
@@ -107,6 +107,22 @@ describe("Authenticated LogIn Component", () => {
     expect(loginButton).toBeTruthy();
     fireEvent.click(loginButton);
     expect(window.location.assign).toHaveBeenCalledOnce();
+  });
+  
+  it("removes user from local storage when logging out", () => {
+    expect(document.getElementById("side-nav-button")).toBeTruthy();
+    expect(localStorage.getItem("user")).toBeTruthy();
+    
+    // Open side nav
+    const hamburgerMenu: HTMLElement = document.getElementById("side-nav-button")!;
+    fireEvent.click(hamburgerMenu);
+    
+    // Click logout button
+    const logoutButton = screen.getByText("Log Out");
+    fireEvent.click(logoutButton);
+
+    expect(window.location.assign).toHaveBeenCalledOnce(); // Redirect to backend auth/google/logout endpoint
+    expect(localStorage.getItem("user")).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
# Overview

This PR fixes a variety of bugs that were introduced while switching auth to the backend. As well as this, it adds frontend tests for the login page. Most of the changes are pretty small aside from the addition of real tests of the login page.

## Fixes

- Cancelling auth now redirects back to `/auth/google/login`
- No longer auto-logs in when user only has one google account
- "user" is removed from localstorage on logout
- logIn page is now actually tested in vitest
    - This includes using `window.location.assign` instead of `window.location.href` to provide actual testability as well as restructuring elements in the about page.
- Updated information in the about section to include the Spring 2025 team

# Related Issues

- closes https://github.com/NCAR/chemistry-cafe/issues/102
- closes https://github.com/NCAR/chemistry-cafe/issues/104
- closes https://github.com/NCAR/chemistry-cafe/issues/105
- closes https://github.com/NCAR/chemistry-cafe/issues/74