### PR TITLE
Remote host

### DIFF
--- a/chemistry-cafe-nginx.conf
+++ b/chemistry-cafe-nginx.conf
@@ -1,7 +1,34 @@
 server {
     listen 80;
     listen [::]:80;
-    #server_name example.org
+    server_name www.chemcaf3.duckdns.org;
 
     return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name www.chemcaf3.duckdns.org;
+
+    #ssl_protocols TLSv1.3 TLSv1.2;
+
+    ssl_certificate /etc/letsencrypt/live/chemcaf3.duckdns.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/chemcaf3.duckdns.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/chemcaf3.duckdns.org/chain.pem;
+
+    
+
+   location / { 
+        proxy_pass http://localhost:5173;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    } 
 }

--- a/chemistry-cafe-nginx.conf
+++ b/chemistry-cafe-nginx.conf
@@ -1,4 +1,5 @@
 server {
+    # redirect HTTP to HTTPS
     listen 80;
     listen [::]:80;
     server_name www.chemcaf3.duckdns.org;
@@ -10,19 +11,20 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
+    # DNS name from duckdns.org
     server_name www.chemcaf3.duckdns.org;
 
     #ssl_protocols TLSv1.3 TLSv1.2;
 
+    # SSL certificate from certbot
     ssl_certificate /etc/letsencrypt/live/chemcaf3.duckdns.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/chemcaf3.duckdns.org/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/chemcaf3.duckdns.org/chain.pem;
 
-    
-
-   location / { 
+    # frontend
+    location / { 
         proxy_pass http://localhost:5173;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/chemistry-cafe-nginx.conf
+++ b/chemistry-cafe-nginx.conf
@@ -11,8 +11,10 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
+    add_header X-dbg-name "chem-caf3" always;
+
     # DNS name from duckdns.org
-    server_name www.chemcaf3.duckdns.org;
+    server_name chemcaf3.duckdns.org;
 
     #ssl_protocols TLSv1.3 TLSv1.2;
 
@@ -23,8 +25,36 @@ server {
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
     ssl_trusted_certificate /etc/letsencrypt/live/chemcaf3.duckdns.org/chain.pem;
 
+    location /signin-google/ {
+        add_header X-auth-dbg "authenticating" always;
+
+        proxy_pass http://localhost:8080/signin-google/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+    }
+
+    location /api/ { 
+        # access_log /var/log/nginx/api.log;
+        add_header X-debug $request_uri always;
+
+        proxy_pass http://localhost:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        # proxy_pass http://127.0.0.1:8080/api/$request_uri;
+        fastcgi_intercept_errors off;
+    }
+
     # frontend
-    location / { 
+    location / {
+        add_header X-debug-msg "frontend" always;
         proxy_pass http://localhost:5173;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -32,5 +62,5 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Protocol $scheme;
         proxy_set_header X-Forwarded-Host $http_host;
-    } 
+    }
 }

--- a/chemistry-cafe-nginx.conf
+++ b/chemistry-cafe-nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+    listen [::]:80;
+    #server_name example.org
+
+    return 301 https://$host$request_uri;
+}


### PR DESCRIPTION
Made an NGINX configuration to allow for a staging environment. Both the frontend and backend are accessible from https://chemcaf3.duckdns.org and https://chemcaf3.duckdns.org/api respectively.