### PR TITLE
Production Containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ MYSQL_PASSWORD=chemistrycafe
 MYSQL_DATABASE=chemistry_db
 
 # Optional with defaults
-GOOGLE_CALLBACK_PATH=/signin-google
 MYSQL_SERVER=localhost
 MYSQL_PORT=3306
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ MYSQL_PORT=3306
 
 In order to use Google Authentication, a Google Cloud OAuth 2.0 project must be used with a `client id` and `client secret`. When creating the project, `http://localhost:8080/signin-google` should be added to the list of "Authorized redirect URIs" for testing.
 
+`FRONTEND_HOST` and `BACKEND_BASE_URL` are required in a production environment. `FRONTEND_HOST` contains where the frontend is served and `BACKEND_BASE_URL` specifies what the backend urls should be prefixed with (eg. "/api/").
+
 **Note:**
 
 - When running locally, the `.env` file must be in the `/backend` directory. 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ MYSQL_DATABASE=chemistry_db
 # Optional with defaults
 MYSQL_SERVER=localhost
 MYSQL_PORT=3306
+FRONTEND_HOST=http://localhost:5173
+BACKEND_BASE_URL=/
 ```
 
 In order to use Google Authentication, a Google Cloud OAuth 2.0 project must be used with a `client id` and `client secret`. When creating the project, `http://localhost:8080/signin-google` should be added to the list of "Authorized redirect URIs" for testing.
@@ -130,6 +132,54 @@ reportgenerator -reports:"TestResults\<guid>\<file-prefix>.cobertura.xml" -targe
 ```
 If all tests past, the coverage report will generate in backend/coveragereport/index.html
 
+
+## Production
+
+### Environment Setup
+
+To build for production, there is a provided `docker-compose.production.yml` file. A `.env` file in the root directory is *required* to specify environment variables of the production containers. The `.env` file should look like the following:
+
+```py
+# Required
+MYSQL_USER=chemistrycafe
+MYSQL_PASSWORD=very_strong_mysqlpassw0rd # Needless to say, do not use this as the actual password
+MYSQL_DATABASE=chemistry_db
+MYSQL_ROOT_PASSWORD=dontsharethiswithanyonebecausethatwouldbebad
+GOOGLE_CLIENT_ID=<client_id>
+GOOGLE_CLIENT_SECRET=<client_secret>
+FRONTEND_HOST=https://<domain>
+BACKEND_BASE_URL=/api # This would be / if testing on localhost:8080
+
+#Optional with defaults
+MYSQL_SERVER=mysql
+MYSQL_PORT=3306
+```
+
+- **Note**: compared to the development environment, the frontend requires more variables to be specified. This is to ensure less implicit functionality.
+- The `FRONTEND_HOST` variable should not have a trailing slash. This is because CORS policies treat `https://<domain>` and `https://<domain>/` as different routes.
+
+#### Frontend variables
+
+The frontend requires a file named `.env.production` in its directory. This is because the final container will serve a static site to the user and it pulls the variables from this file instead
+
+```py
+VITE_BASE_URL=http://localhost:8080/api  # Backend API endpoint
+VITE_AUTH_URL=http://localhost:8080/auth # Backend auth endpoint
+```
+
+**For Contributors**: Do *not* put secrets in this environment file. These environment variables are served directly to the web browser meaning they are *public*. Any functionality requiring API keys should solely be dealt with in the backend.
+
+- It's very easy to be tempted with an npm package that uses environment variables to call an external API. Many have fallen victim to this security vulnerability in the past.
+
+### To run the production containers:
+
+```
+docker compose -f ./docker-compose.production.yml up -d
+```
+
+After each container is built and running, the backend will be served in port `8080` and the frontend will be served on port `5173` just like the development environment. 
+
+To actually serve these containers to the world, 
 
 # License
 - [Apache 2.0](/LICENSE)

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -18,4 +18,3 @@
 !appsettings.Development.json
 !appsettings.Production.json
 !appsettings.json
-!.env

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -494,3 +494,6 @@ bin
 
 # Test files
 TestResults
+
+# Production configuration
+appsettings.Production.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,7 @@ EXPOSE 8081
 FROM base AS build
 
 ARG BUILD_CONFIGURATION=Release
+ARG BUILD_ARCH=linux-x64
 
 WORKDIR /ChemistryCafeBackend
 RUN dotnet restore "./ChemistryCafeAPI.csproj"
@@ -18,7 +19,7 @@ RUN dotnet build "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/bui
 FROM build AS publish
 
 WORKDIR /ChemistryCafeBackend
-RUN dotnet publish "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish --self-contained -r linux-x64
+RUN dotnet publish "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish --self-contained -r $BUILD_ARCH
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS final
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,20 +4,30 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 COPY . ChemistryCafeBackend/
 WORKDIR /ChemistryCafeBackend
 
-# Creates the production build
+EXPOSE 8080
+EXPOSE 8081
+
 FROM base AS build
 
 ARG BUILD_CONFIGURATION=Release
 
+WORKDIR /ChemistryCafeBackend
 RUN dotnet restore "./ChemistryCafeAPI.csproj"
 RUN dotnet build "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+FROM build AS publish
+
+WORKDIR /ChemistryCafeBackend
 RUN dotnet publish "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish --self-contained -r linux-x64
 
-WORKDIR /app/build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS final
 
+WORKDIR /ChemistryCafeBackend
+COPY --from=publish /app/publish .
+
+# Default published binary port
+EXPOSE 5000
 USER app
-EXPOSE 8080
-EXPOSE 8081
 
 # Default command for production
 ENTRYPOINT ["./ChemistryCafeAPI"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,13 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS final
-
-ARG BUILD_CONFIGURATION=Release
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 
 COPY . ChemistryCafeBackend/
 WORKDIR /ChemistryCafeBackend
+
+# Creates the production build
+FROM base AS build
+
+ARG BUILD_CONFIGURATION=Release
 
 RUN dotnet restore "./ChemistryCafeAPI.csproj"
 RUN dotnet build "./ChemistryCafeAPI.csproj" -c $BUILD_CONFIGURATION -o /app/build

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -35,7 +35,6 @@ builder.Services.AddScoped<GoogleOAuthService>();
 
 string googleClientId = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_ID") ?? throw new InvalidOperationException("GOOGLE_CLIENT_ID environment variable is missing.");
 string googleClientSecret = Environment.GetEnvironmentVariable("GOOGLE_CLIENT_SECRET") ?? throw new InvalidOperationException("GOOGLE_CLIENT_SECRET environment variable is missing.");
-string googleCallbackPath = Environment.GetEnvironmentVariable("GOOGLE_CALLBACK_PATH").IsNullOrEmpty() ? "/signin-google" : Environment.GetEnvironmentVariable("GOOGLE_CALLBACK_PATH")!;
 
 builder.Services.AddAuthentication((options) =>
     {
@@ -48,7 +47,6 @@ builder.Services.AddAuthentication((options) =>
     {
         options.ClientId = googleClientId;
         options.ClientSecret = googleClientSecret;
-        options.CallbackPath = googleCallbackPath;
         options.AccessDeniedPath = "/auth/google/login";
     });
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -69,6 +69,7 @@ var connectionString = $"Server={server};Port={port};Database={database};User={u
 builder.Services.AddMySqlDataSource(connectionString);
 builder.Services.AddDbContext<ChemistryDbContext>(options => options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)));
 
+string frontendHost = Environment.GetEnvironmentVariable("FRONTEND_HOST") ?? "http://localhost:5173";
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("DevelopmentCorsPolicy", policy =>
@@ -81,7 +82,7 @@ builder.Services.AddCors(options =>
 
     options.AddPolicy("ProductionCorsPolicy", policy =>
     {
-        policy.WithOrigins("https://cafe-deux-devel.acom.ucar.edu")
+        policy.WithOrigins(frontendHost)
                .AllowAnyMethod()
                .AllowAnyHeader()
                .AllowCredentials();

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,9 +26,13 @@ MYSQL_DATABASE=chemistry_db
 GOOGLE_CALLBACK_PATH=/signin-google
 MYSQL_SERVER=localhost
 MYSQL_PORT=3306
+FRONTEND_HOST=http://localhost:5173/
+BACKEND_BASE_URL=/api/
 ```
 
 `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found in a google cloud project. These variables may be set in a `.env` file in the `/backend` directory or created on the machine itself.
+
+`FRONTEND_HOST` specifies where the frontend is located and `BACKEND_BASE_URL` specifies what prefix the backend is on for its current host.  
 
 ## Command line
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,7 +23,6 @@ MYSQL_PASSWORD=chemistrycafe
 MYSQL_DATABASE=chemistry_db
 
 # Optional with defaults
-GOOGLE_CALLBACK_PATH=/signin-google
 MYSQL_SERVER=localhost
 MYSQL_PORT=3306
 FRONTEND_HOST=http://localhost:5173/

--- a/backend/README.md
+++ b/backend/README.md
@@ -25,8 +25,8 @@ MYSQL_DATABASE=chemistry_db
 # Optional with defaults
 MYSQL_SERVER=localhost
 MYSQL_PORT=3306
-FRONTEND_HOST=http://localhost:5173/
-BACKEND_BASE_URL=/api/
+FRONTEND_HOST=http://localhost:5173
+BACKEND_BASE_URL=/
 ```
 
 `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found in a google cloud project. These variables may be set in a `.env` file in the `/backend` directory or created on the machine itself.

--- a/backend/appsettings.Development.json
+++ b/backend/appsettings.Development.json
@@ -4,6 +4,5 @@
             "Default": "Debug",
             "Microsoft.AspNetCore": "Debug"
         }
-    },
-    "FrontendHost": "http://localhost:5173"
+    }
 }

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -5,6 +5,5 @@
             "Microsoft.AspNetCore": "Debug"
         }
     },
-    "AllowedHosts": "*",
-    "FrontendHost": "http://localhost:5173"
+    "AllowedHosts": "*"
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -54,7 +54,7 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?error}
       MYSQL_PORT: ${MYSQL_PORT:-3306}
       FRONTEND_HOST: ${FRONTEND_HOST:?error}
-      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-/}
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:?error}
     networks:
       - app-network
     depends_on:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,5 +1,5 @@
 x-db-env: &db-env
-  MYSQL_SERVER: ${MYSQL_SERVER:?error}
+  MYSQL_SERVER: ${MYSQL_SERVER:-mysql}
   MYSQL_USER: ${MYSQL_USER:?error}
   MYSQL_PASSWORD: ${MYSQL_PASSWORD:?error}
   MYSQL_DATABASE: ${MYSQL_DATABASE:?error}
@@ -38,7 +38,6 @@ services:
     depends_on:
       - backend_production
     restart: on-failure:4
-    
   
   backend_production:
     container_name: backend_production
@@ -53,6 +52,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?error}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?error}
+      MYSQL_PORT: ${MYSQL_PORT:-3306}
       FRONTEND_HOST: ${FRONTEND_HOST:?error}
       BACKEND_BASE_URL: ${BACKEND_BASE_URL:-/}
     networks:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -45,6 +45,8 @@ services:
       context: ./backend # Path to your back-end repository
       dockerfile: Dockerfile
       target: final
+      args:
+        BUILD_ARCH: ${BUILD_ARCH:-linux-x64}
     ports:
       - "8080:5000" # Map host port to container port
     environment:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,71 @@
+x-db-env: &db-env
+  MYSQL_SERVER: ${MYSQL_SERVER:?error}
+  MYSQL_USER: ${MYSQL_USER:?error}
+  MYSQL_PASSWORD: ${MYSQL_PASSWORD:?error}
+  MYSQL_DATABASE: ${MYSQL_DATABASE:?error}
+
+services:
+  mysql:
+    image: mysql:9.0
+    container_name: mysql
+    ports:
+      - "3306:3306" # MySQL default port
+    volumes:
+      - db_data_production:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql # run initial sql script
+    environment:
+      <<: *db-env
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?error}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - app-network
+    restart: on-failure:4
+
+  frontend_production:
+    container_name: frontend_production
+    build:
+      context: ./frontend # Path to your front-end repository
+      dockerfile: Dockerfile
+      target: final
+    ports:
+      - "5173:80"
+    networks:
+      - app-network
+    depends_on:
+      - backend_production
+    restart: on-failure:4
+    
+  
+  backend_production:
+    container_name: backend_production
+    build:
+      context: ./backend # Path to your back-end repository
+      dockerfile: Dockerfile
+      target: final
+    ports:
+      - "8080:5000" # Map host port to container port
+    environment:
+      <<: *db-env
+      ASPNETCORE_ENVIRONMENT: Production
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?error}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?error}
+      FRONTEND_HOST: ${FRONTEND_HOST:?error}
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-/}
+    networks:
+      - app-network
+    depends_on:
+      - mysql
+    env_file:
+      - path: ./.env
+        required: true
+    restart: on-failure:4
+
+volumes:
+  db_data_production:
+networks:
+  app-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,11 @@ services:
     build:
       context: ./frontend # Path to your front-end repository
       dockerfile: Dockerfile
-      target: build
+      target: base
     ports:
       - "5173:5173"
-    depends_on:
-      - backend # Ensure the backend service starts before frontend
     environment:
-      # - ASPNETCORE_ENVIRONMENT=Development
-      # - ASPNETCORE_URLS=http://0.0.0.0:8080
+      - ASPNETCORE_ENVIRONMENT=Development
       - API_URL=http://backend:8080 # This points to the backend service within the Docker network
     networks:
       - app-network
@@ -56,6 +53,7 @@ services:
     build:
       context: ./backend # Path to your back-end repository
       dockerfile: Dockerfile
+      target: base
     ports:
       - "8080:8080" # Map host port to container port
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     build:
       context: ./frontend # Path to your front-end repository
       dockerfile: Dockerfile
+      target: build
     ports:
       - "5173:5173"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 x-db-env: &db-env
-  MYSQL_SERVER: mysql
-  MYSQL_USER: chemistrycafedev
-  MYSQL_PASSWORD: chemistrycafe
-  MYSQL_DATABASE: chemistry_db
+  MYSQL_SERVER: ${MYSQL_SERVER:-mysql}
+  MYSQL_USER: ${MYSQL_USER:-chemistrycafedev}
+  MYSQL_PASSWORD: ${MYSQL_PASSWORD:-chemistrycafe}
+  MYSQL_DATABASE: ${MYSQL_DATABASE:-chemistry_db}
 
 services:
   mysql:
@@ -23,6 +23,7 @@ services:
       retries: 5
     networks:
       - app-network
+  
   frontend:
     container_name: frontend
     build:
@@ -31,9 +32,6 @@ services:
       target: base
     ports:
       - "5173:5173"
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - API_URL=http://backend:8080 # This points to the backend service within the Docker network
     networks:
       - app-network
     # test code by britt to enable live updates to frontend with docker
@@ -48,23 +46,29 @@ services:
         - action: rebuild
           path: package.json
     command: ["npm", "run", "dev"] # Command for development
+  
   backend:
     container_name: backend
     build:
       context: ./backend # Path to your back-end repository
       dockerfile: Dockerfile
-      target: base
+      target: build
+      args:
+        BUILD_CONFIGURATION: Debug
     ports:
       - "8080:8080" # Map host port to container port
     environment:
       <<: *db-env
       ASPNETCORE_ENVIRONMENT: Development
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      GOOGLE_CALLBACK_PATH: ${GOOGLE_CALLBACK_PATH}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?error}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?error}
+      FRONTEND_HOST: ${FRONTEND_HOST:-http://localhost:5173}
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-/}
+    depends_on:
+      - mysql
     networks:
       - app-network
-    command: ["dotnet", "watch", "run", "--project", "ChemistryCafeAPI.csproj"] # Command for development
+    command: ["dotnet", "watch", "run", "--project", "ChemistryCafeAPI.csproj", "--urls", "http://0.0.0.0:8080"] # Command for development
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
     environment:
       <<: *db-env
       ASPNETCORE_ENVIRONMENT: Development
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:?error}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:?error}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       FRONTEND_HOST: ${FRONTEND_HOST:-http://localhost:5173}
       BACKEND_BASE_URL: ${BACKEND_BASE_URL:-/}
     depends_on:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -19,3 +19,4 @@
 !vitest.config.ts
 !vitest.setup.ts
 !public
+!nginx.conf

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,0 @@
-VITE_BASE_URL=https://cafe-deux.acom.ucar.edu/api/api
-VITE_AUTH_URL=https://cafe-deux.acom.ucar.edu/api/auth

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,4 @@ dist-ssr
 
 node_modules/
 /coverage
+.env.production

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,8 +15,8 @@ FROM base AS build
 # Create a production build
 RUN npm run build
 
-# Second stage serves static files. This stage is used in the production build
-FROM nginx:latest AS serve
+# Third stage serves static files. This stage is used in the production build
+FROM nginx:latest AS final
 
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /ChemistryCafeFrontend/dist /usr/share/nginx/html

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,16 +1,25 @@
 # Use the official Node.js image to build and run the back-end project
-FROM node:18
+# This stage is used for both the production and development build
+FROM node:18 AS build
 
 COPY . ChemistryCafeFrontend/
 WORKDIR /ChemistryCafeFrontend
 
 RUN npm install
 
-# Expose the API port
+# Expose the development API port
 EXPOSE 5173
 
 # Create a production build
 RUN npm run build
 
-# Default command for production
-CMD ["npm", "run", "start"]
+# Second stage serves static files. This stage is used in the production build
+FROM nginx:latest AS serve
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /ChemistryCafeFrontend/dist /usr/share/nginx/html
+
+# Expose the production API port
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official Node.js image to build and run the back-end project
 # This stage is used for both the production and development build
-FROM node:18 AS build
+FROM node:18 AS base
 
 COPY . ChemistryCafeFrontend/
 WORKDIR /ChemistryCafeFrontend
@@ -9,6 +9,8 @@ RUN npm install
 
 # Expose the development API port
 EXPOSE 5173
+
+FROM base AS build
 
 # Create a production build
 RUN npm run build

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+# Config file used for serving static files in docker container
+server {
+    listen 80;
+    server_name frontend;
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
# Overview

This PR addresses some concerns involving the docker development environment as well as configuring the docker containers so they can be used in production. In addition to this, the *development* containers no longer builds the entire project meaning they spin up much faster than before. 

In addition to this, it paves the way to a much more concise CI/CD pipeline which includes database migrations and app tests in docker compose so the github workflow doesn't need to ping the database 30 times.

# Changes

- Production containers now exist
- Removes GOOGLE_CALLBACK_PATH environment variable since this was a hack to get the backend working a couple weeks ago.
- More environment variables for the backend to deal with things like having a base url of `/api`
- Smaller Container Sizes
    - Before:
        - backend: 2.58 GB
        - frontend: 1.33 GB
    - After:
        - backend dev: 1.98 GB
        - frontend dev: 1.32 GB
        - backend production: 1.04 GB
        - frontend production: 0.19 GB (195.46 MB)

# Related Issues

- closes https://github.com/NCAR/chemistry-cafe/issues/126
- https://github.com/NCAR/chemistry-cafe/issues/125