### PR TITLE
Updated Citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: If you use this software, please cite it as below.
-title: Chemistry Cafes
-version: 0.0.0
+title: Chemistry Cafe
+version: 1.6.1
 authors:
   - family-names: Dawson
     given-names: Matthew
@@ -36,4 +36,4 @@ authors:
   - family-names: Fontenot
     given-names: James
 license: Apache-2.0
-url: "https://github.com/NCAR/music-box-interactive-client"
+url: "https://github.com/NCAR/chemistry-cafe"


### PR DESCRIPTION
I noticed that the original citation for this repository was pointing towards musicbox at `https://github.com/NCAR/music-box-interactive-client` and realized some of the other information was also out of date. Wasn't completely sure if it was meant to be "Chemistry Cafes" to refer to both versions or if it is supposed to be "Chemistry Cafe"