### PR TITLE
create a migration and update the database when docker compose starts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 
+RUN apt-get update && apt-get install -y iputils-ping default-mysql-client && rm -rf /var/lib/apt/lists/*
+
+RUN dotnet tool install --global dotnet-ef
+ENV PATH="$PATH:/root/.dotnet/tools"
+
 COPY . ChemistryCafeBackend/
 WORKDIR /ChemistryCafeBackend
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,16 @@ services:
       - mysql
     networks:
       - app-network
-    command: ["dotnet", "watch", "run", "--project", "ChemistryCafeAPI.csproj", "--urls", "http://0.0.0.0:8080"] # Command for development
+    command: >
+      sh -c "
+      until mysqladmin ping -h mysql --silent; do
+        echo 'Waiting for MySQL to be ready...';
+        sleep 2;
+      done &&
+      dotnet ef migrations add DockerMigrations --project ChemistryCafeAPI.csproj &&
+      dotnet ef database update &&
+      dotnet watch run --project ChemistryCafeAPI.csproj --urls http://0.0.0.0:8080
+      "
 
 volumes:
   db_data:


### PR DESCRIPTION
Adds a step in the docker compose file to create a migration and update the database. This allows `docker compose build` and `docker compose up` to work out of the box