### PR TITLE
Relink gas phase on deserialization

### DIFF
--- a/frontend/src/helpers/musicaAdapter.ts
+++ b/frontend/src/helpers/musicaAdapter.ts
@@ -314,7 +314,6 @@ const TUNNELING: ReactionAdapter = {
 
 const SURFACE: ReactionAdapter = {
   toMusica: (r, ctx) => {
-    console.log("SURFACE toMusica", r, ctx);
     return new reactionTypes.Surface({
       name: r.name,
       reaction_probability: num(paramVal(r, "reaction probability"), 1.0),
@@ -330,7 +329,6 @@ const SURFACE: ReactionAdapter = {
   },
 
   fromMusica: (json) => {
-    console.log("SURFACE fromMusica", json);
     return {
       id: generateFrontendID(),
       name: json.name ?? "",

--- a/frontend/src/helpers/musicaAdapter.ts
+++ b/frontend/src/helpers/musicaAdapter.ts
@@ -196,26 +196,31 @@ const EMISSION: ReactionAdapter = {
 };
 
 const PHOTOLYSIS: ReactionAdapter = {
-  toMusica: (r, ctx) =>
-    new reactionTypes.Photolysis({
+  toMusica: (r, ctx) => {
+    console.log("photolysis toMusica reaction: ", r);
+    return new reactionTypes.Photolysis({
       name: r.name,
       scaling_factor: num(paramVal(r, SCALING_FACTOR_KEY), 1.0),
       gas_phase: r.gasPhaseId ? ctx.phaseName(String(r.gasPhaseId)) : undefined,
       reactants: componentsToMusica(r.reactants, ctx),
       products: componentsToMusica(r.products, ctx),
-    }),
+    })
+  },
 
-  fromMusica: (json) => ({
+  fromMusica: (json) => {
+    console.log("photolysis fromMusica json: ", json);
+    return {
     id: generateFrontendID(),
     name: json.name ?? "",
     description: null,
+    gasPhaseId: json.gas_phase,
     type: reactionTypes.Photolysis.type,
     attributes: attrsFromParams({
       [SCALING_FACTOR_KEY]: json[SCALING_FACTOR_KEY],
     }),
     reactants: componentsFromJSON(json.reactants),
     products: componentsFromJSON(json.products),
-  }),
+  }},
 };
 
 const FIRST_ORDER_LOSS: ReactionAdapter = {
@@ -464,9 +469,12 @@ export function deserializeMechanism(parsed: Record<string, any>): Family {
   }
 
   // 2. phases — resolve member species names back to ids.
+  const phaseToId = new Map<string, string>();
   for (const p of parsed.phases) {
+    const id = generateFrontendID();
+    phaseToId.set(p.name, id);
     family.phases.push({
-      id: generateFrontendID(),
+      id,
       name: p.name,
       description: null,
       speciesIds: (p.species ?? [])
@@ -487,7 +495,9 @@ export function deserializeMechanism(parsed: Record<string, any>): Family {
       continue;
     }
     let reaction = adapter.fromMusica(r);
-    family.reactions.push(linkComponentIds(reaction, nameToId));
+    reaction = linkPhaseIds(reaction, phaseToId);
+    reaction = linkComponentIds(reaction, nameToId);
+    family.reactions.push(reaction);
   }
 
   return family;
@@ -535,5 +545,12 @@ function linkComponentIds(
     ...r,
     reactants: r.reactants.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
     products: r.products.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
+  };
+}
+
+function linkPhaseIds(r: Reaction, nameToId: Map<string, string>) {
+  return {
+    ...r,
+    gasPhaseId: r.gasPhaseId ? nameToId.get(String(r.gasPhaseId)) ?? r.gasPhaseId : undefined,
   };
 }

--- a/frontend/src/helpers/musicaAdapter.ts
+++ b/frontend/src/helpers/musicaAdapter.ts
@@ -122,6 +122,7 @@ const ARRHENIUS: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.Arrhenius.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({
       A: json.A,
       B: json.B,
@@ -159,6 +160,7 @@ const BRANCHED_NO_RO2: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.Branched.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({
       X: json.X,
       Y: json.Y,
@@ -187,6 +189,7 @@ const EMISSION: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.Emission.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({
       [SCALING_FACTOR_KEY]: json[SCALING_FACTOR_KEY],
     }),
@@ -197,7 +200,6 @@ const EMISSION: ReactionAdapter = {
 
 const PHOTOLYSIS: ReactionAdapter = {
   toMusica: (r, ctx) => {
-    console.log("photolysis toMusica reaction: ", r);
     return new reactionTypes.Photolysis({
       name: r.name,
       scaling_factor: num(paramVal(r, SCALING_FACTOR_KEY), 1.0),
@@ -208,19 +210,20 @@ const PHOTOLYSIS: ReactionAdapter = {
   },
 
   fromMusica: (json) => {
-    console.log("photolysis fromMusica json: ", json);
-    return {
-    id: generateFrontendID(),
-    name: json.name ?? "",
-    description: null,
-    gasPhaseId: json.gas_phase,
-    type: reactionTypes.Photolysis.type,
-    attributes: attrsFromParams({
-      [SCALING_FACTOR_KEY]: json[SCALING_FACTOR_KEY],
-    }),
-    reactants: componentsFromJSON(json.reactants),
-    products: componentsFromJSON(json.products),
-  }},
+    let obj = {
+      id: generateFrontendID(),
+      name: json.name ?? "",
+      description: null,
+      gasPhaseId: json["gas phase"] ?? undefined,
+      type: reactionTypes.Photolysis.type,
+      attributes: attrsFromParams({
+        [SCALING_FACTOR_KEY]: json[SCALING_FACTOR_KEY],
+      }),
+      reactants: componentsFromJSON(json.reactants),
+      products: componentsFromJSON(json.products),
+    }
+    return obj;
+  },
 };
 
 const FIRST_ORDER_LOSS: ReactionAdapter = {
@@ -237,6 +240,7 @@ const FIRST_ORDER_LOSS: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.FirstOrderLoss.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({
       [SCALING_FACTOR_KEY]: json[SCALING_FACTOR_KEY],
     }),
@@ -246,7 +250,7 @@ const FIRST_ORDER_LOSS: ReactionAdapter = {
 };
 
 const TROE: ReactionAdapter = {
-  toMusica: (r, ctx) => 
+  toMusica: (r, ctx) =>
     new reactionTypes.Troe({
       name: r.name,
       k0_A: num(paramVal(r, "k0_A"), 1.0),
@@ -267,6 +271,7 @@ const TROE: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.Troe.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({
       k0_A: json.k0_A,
       k0_B: json.k0_B,
@@ -300,22 +305,17 @@ const TUNNELING: ReactionAdapter = {
     name: json.name ?? "",
     description: null,
     type: reactionTypes.Tunneling.type,
+    gasPhaseId: json["gas phase"] ?? undefined,
     attributes: attrsFromParams({ A: json.A, B: json.B, C: json.C }),
     reactants: componentsFromJSON(json.reactants),
     products: componentsFromJSON(json.products),
   }),
 };
 
-// SURFACE: heterogeneous reaction with a single gas-phase species and a set of
-// gas-phase products. The single species comes from the reaction's
-// gasPhaseSpeciesId; products carry the "gas-phase" branch.
-// NOTE: musica's Surface.getJSON() requires gas_phase_species, so it is always
-// constructed (an unresolved id yields its raw value as the name). The editor
-// UI for setting gasPhaseSpeciesId, and relinking it on import, remain part of
-// #237 / #238.
 const SURFACE: ReactionAdapter = {
-  toMusica: (r, ctx) =>
-    new reactionTypes.Surface({
+  toMusica: (r, ctx) => {
+    console.log("SURFACE toMusica", r, ctx);
+    return new reactionTypes.Surface({
       name: r.name,
       reaction_probability: num(paramVal(r, "reaction probability"), 1.0),
       gas_phase: r.gasPhaseId ? ctx.phaseName(String(r.gasPhaseId)) : undefined,
@@ -326,21 +326,25 @@ const SURFACE: ReactionAdapter = {
         r.products.filter((p) => p.branch === "gas-phase"),
         ctx,
       ),
-    }),
+    });
+  },
 
-  fromMusica: (json) => ({
-    id: generateFrontendID(),
-    name: json.name ?? "",
-    description: null,
-    type: reactionTypes.Surface.type,
-    attributes: attrsFromParams({
-      "reaction probability": json["reaction probability"],
-    }),
-    reactants: [],
-    products: componentsFromJSON(json["gas-phase products"], "gas-phase"),
-    // Arrives as a species *name*; relinking to an id is tracked in #238.
-    gasPhaseSpeciesId: json["gas-phase species"],
-  }),
+  fromMusica: (json) => {
+    console.log("SURFACE fromMusica", json);
+    return {
+      id: generateFrontendID(),
+      name: json.name ?? "",
+      description: null,
+      type: reactionTypes.Surface.type,
+      gasPhaseId: json["gas phase"] ?? undefined,
+      attributes: attrsFromParams({
+        "reaction probability": json["reaction probability"],
+      }),
+      reactants: [],
+      products: componentsFromJSON(json["gas-phase products"], "gas-phase"),
+      gasPhaseSpeciesId: json["gas-phase species"],
+    }
+  },
 };
 
 const REACTION_ADAPTERS: Partial<Record<ReactionTypeName, ReactionAdapter>> = {
@@ -541,10 +545,23 @@ function linkComponentIds(
 ): Reaction {
   const toId = (speciesId: Reactant["speciesId"]) =>
     nameToId.get(String(speciesId)) ?? speciesId;
-  return {
-    ...r,
-    reactants: r.reactants.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
-    products: r.products.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
+  if (r.type === reactionTypes.Surface.type) {
+    return {
+      ...r,
+      gasPhaseSpeciesId: r.gasPhaseSpeciesId
+        ? toId(r.gasPhaseSpeciesId)
+        : undefined,
+      products: r.products.map((c) =>
+        c.branch === "gas-phase" ? { ...c, speciesId: toId(c.speciesId) } : c,
+      ),
+    }
+  }
+  else {
+    return {
+      ...r,
+      reactants: r.reactants.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
+      products: r.products.map((c) => ({ ...c, speciesId: toId(c.speciesId) })),
+    }
   };
 }
 

--- a/frontend/src/helpers/musicaAdapter.ts
+++ b/frontend/src/helpers/musicaAdapter.ts
@@ -241,7 +241,7 @@ const FIRST_ORDER_LOSS: ReactionAdapter = {
 };
 
 const TROE: ReactionAdapter = {
-  toMusica: (r, ctx) =>
+  toMusica: (r, ctx) => 
     new reactionTypes.Troe({
       name: r.name,
       k0_A: num(paramVal(r, "k0_A"), 1.0),
@@ -486,7 +486,8 @@ export function deserializeMechanism(parsed: Record<string, any>): Family {
       console.warn(`Unsupported reaction type on import: ${r.type}`);
       continue;
     }
-    family.reactions.push(linkComponentIds(adapter.fromMusica(r), nameToId));
+    let reaction = adapter.fromMusica(r);
+    family.reactions.push(linkComponentIds(reaction, nameToId));
   }
 
   return family;

--- a/frontend/src/types/chemistryModels.ts
+++ b/frontend/src/types/chemistryModels.ts
@@ -135,7 +135,7 @@ export type Reaction = {
   /** Type of the reaction. This determines what other properties the reaction should have */
   type: ReactionTypeName;
 
-  /** Optional id for the gas phase. Required in certain reactions */
+  /** Optional id for the gas phase. Required in all reactions */
   gasPhaseId?: UUID | string | null;
 
   /** Optional id for the gas phase species. Required in certain reactions */

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import {
   Family,
   Mechanism,
@@ -258,15 +258,37 @@ const family: Family = {
 const serialize = (m = mechanism, f = family): Record<string, any> =>
   JSON.parse(serializeMechanismJSON(m, f));
 
-const serialized = serialize();
+// Built once per consuming suite in `beforeAll(initFixtures)` (see below), so
+// the shared serialize/deserialize runs inside those suites — not at module
+// load, and not for the mechanism serialization tests, which have no beforeAll.
+let serialized: Record<string, any>;
+let imported: Family;
+
+const initFixtures = () => {
+  serialized = serialize();
+  imported = deserializeV1Mechanism(serializeMechanismJSON(mechanism, family))!;
+};
 
 /** Find the serialized reaction of a given type. */
 const reactionOfType = (type: string): Record<string, any> =>
   serialized.reactions.find((r: any) => r.type === type);
 
-const reactionHasGasPhase = (reaction: Reaction, gasPhaseId: string): boolean => {
-  return reaction.gasPhaseId !== undefined && reaction.gasPhaseId !== null && reaction.gasPhaseId === gasPhaseId;
-}
+/** Find the deserialized (round-tripped) reaction of a given type. The imported
+ * family carries fresh frontend ids, so component references resolve back to
+ * species by name via `importedName`. */
+const importedReactionOfType = (type: string): Reaction =>
+  imported.reactions.find((r) => r.type === type)!;
+
+const importedName = (speciesId: string): string | undefined =>
+  imported.species.find((s) => s.id === speciesId)?.name;
+
+const importedGasPhase = (): Phase | undefined =>
+  imported.phases.find((p) => p.name === "gas");
+
+const reactionHasGasPhase = (reaction: Reaction, gasPhaseId: string): boolean =>
+  reaction.gasPhaseId !== undefined &&
+  reaction.gasPhaseId !== null &&
+  reaction.gasPhaseId === gasPhaseId;
 
 describe("Mechanism Serialization", () => {
   it("serializes to a JSON string that deserializes to an object", () => {
@@ -274,7 +296,6 @@ describe("Mechanism Serialization", () => {
     const deserialized = deserializeV1Mechanism(result);
     expect(typeof result).toBe("string");
     expect(typeof deserialized).toBe("object");
-    console.log(deserialized);
     const deserializedGasPhase = deserialized?.phases.find((p) => p.name === "gas");
     expect(deserializedGasPhase).toBeDefined();
     deserialized?.reactions.forEach((reaction) => {
@@ -301,6 +322,8 @@ describe("Mechanism Serialization", () => {
 });
 
 describe("Phase serialization", () => {
+  beforeAll(initFixtures);
+
   it("serializes referenced phases with their member species", () => {
     const phaseNames = serialized.phases.map((p: any) => p.name);
     expect(phaseNames).toContain("gas");
@@ -324,99 +347,207 @@ describe("Phase serialization", () => {
   });
 });
 
-describe("Reaction type serialization", () => {
-  it("ARRHENIUS", () => {
-    const rx = reactionOfType("ARRHENIUS");
-    expect(rx.A).toBe(1);
-    expect(rx.B).toBe(2);
-    expect(rx.Ea).toBe(3); // Ea present, so C omitted
-    expect(rx.C).toBeUndefined();
-    expect(rx.D).toBe(4);
-    expect(rx.E).toBe(5);
-    expect(rx.reactants[0].name).toBe(reactant.name);
-    expect(rx.products[0]).toEqual({ name: product.name, coefficient: 2 });
-    expect(rx["gas phase"]).toBe("gas");
-  });
+describe("Reaction type serialization and deserialization", () => {
+  beforeAll(initFixtures);
 
-  it("ARRHENIUS without Ea falls back to C", () => {
-    // the one case that needs a reaction variant: C and Ea are mutually
-    // exclusive, so the shared (Ea) reaction cannot also cover the C branch.
-    const cReaction: Reaction = {
-      ...arrheniusReaction,
-      id: "reaction-arrhenius-c",
-      attributes: attrs({ A: 1, C: 9 }),
-    };
-    const parsed = serialize(
-      { ...mechanism, reactionIds: [cReaction.id] },
-      { ...family, reactions: [cReaction] },
-    );
-    const rx = parsed.reactions[0];
-    expect(rx.C).toBe(9);
-    expect(rx.Ea).toBeUndefined();
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("BRANCHED_NO_RO2", () => {
-    const rx = reactionOfType("BRANCHED_NO_RO2");
-    expect(rx.X).toBe(1);
-    expect(rx.Y).toBe(2);
-    expect(rx.a0).toBe(3);
-    expect(rx.n).toBe(4);
-    expect(rx["alkoxy products"][0].name).toBe(product.name);
-    expect(rx["nitrate products"][0].name).toBe(reactant.name);
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("EMISSION", () => {
-    const rx = reactionOfType("EMISSION");
-    expect(rx["scaling factor"]).toBe(2.5);
-    expect(rx.products[0].name).toBe(product.name);
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("PHOTOLYSIS", () => {
-    const rx = reactionOfType("PHOTOLYSIS");
-    expect(rx["scaling factor"]).toBe(3);
-    expect(rx.reactants[0].name).toBe(reactant.name);
-    expect(rx.products[0].name).toBe(product.name);
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("FIRST_ORDER_LOSS", () => {
-    const rx = reactionOfType("FIRST_ORDER_LOSS");
-    expect(rx["scaling factor"]).toBe(1.5);
-    expect(rx.reactants[0].name).toBe(reactant.name);
-    expect(rx.products).toBeUndefined(); // no products supplied → key omitted
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("TROE", () => {
-    const rx = reactionOfType("TROE");
-    expect(rx.k0_A).toBe(1);
-    expect(rx.k0_C).toBe(3);
-    expect(rx.kinf_A).toBe(4);
-    expect(rx.Fc).toBe(0.5);
-    expect(rx.N).toBe(1);
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("TUNNELING", () => {
-    const rx = reactionOfType("TUNNELING");
-    expect(rx.A).toBe(1);
-    expect(rx.B).toBe(2);
-    expect(rx.C).toBe(3);
-    expect(rx["gas phase"]).toBe("gas");
-  });
-
-  it("SURFACE", () => {
-    const rx = reactionOfType("SURFACE");
-    expect(rx["reaction probability"]).toBe(0.5);
-    // single gas-phase species resolves to its name
-    expect(rx["gas-phase species"]).toBe(reactant.name);
-    expect(rx["gas-phase products"][0]).toEqual({
-      name: product.name,
-      coefficient: 2,
+  describe("ARRHENIUS", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("ARRHENIUS");
+      expect(rx.A).toBe(1);
+      expect(rx.B).toBe(2);
+      expect(rx.Ea).toBe(3); // Ea present, so C omitted
+      expect(rx.C).toBeUndefined();
+      expect(rx.D).toBe(4);
+      expect(rx.E).toBe(5);
+      expect(rx.reactants[0].name).toBe(reactant.name);
+      expect(rx.products[0]).toEqual({ name: product.name, coefficient: 2 });
+      expect(rx["gas phase"]).toBe("gas");
     });
-    expect(rx["gas phase"]).toBe("gas");
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("ARRHENIUS");
+      expect(back.attributes["A"]?.value).toBe(1);
+      expect(back.attributes["Ea"]?.value).toBe(3);
+      expect(back.attributes["C"]).toBeUndefined();
+      expect(importedName(String(back.reactants[0].speciesId))).toBe(
+        reactant.name,
+      );
+      expect(importedName(String(back.products[0].speciesId))).toBe(
+        product.name,
+      );
+      expect(back.products[0].coefficient).toBe(2);
+    });
+
+    it("serializes with C when Ea is absent", () => {
+      // C and Ea are mutually exclusive, so this needs a reaction variant.
+      const cReaction: Reaction = {
+        ...arrheniusReaction,
+        id: "reaction-arrhenius-c",
+        attributes: attrs({ A: 1, C: 9 }),
+      };
+      const parsed = serialize(
+        { ...mechanism, reactionIds: [cReaction.id] },
+        { ...family, reactions: [cReaction] },
+      );
+      const rx = parsed.reactions[0];
+      expect(rx.C).toBe(9);
+      expect(rx.Ea).toBeUndefined();
+      expect(rx["gas phase"]).toBe("gas");
+    });
+  });
+
+  describe("BRANCHED_NO_RO2", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("BRANCHED_NO_RO2");
+      expect(rx.X).toBe(1);
+      expect(rx.Y).toBe(2);
+      expect(rx.a0).toBe(3);
+      expect(rx.n).toBe(4);
+      expect(rx["alkoxy products"][0].name).toBe(product.name);
+      expect(rx["nitrate products"][0].name).toBe(reactant.name);
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("BRANCHED_NO_RO2");
+      expect(back.attributes["X"]?.value).toBe(1);
+      expect(back.attributes["n"]?.value).toBe(4);
+      const alkoxy = back.products.filter((p) => p.branch === "alkoxy");
+      const nitrate = back.products.filter((p) => p.branch === "nitrate");
+      expect(importedName(String(alkoxy[0].speciesId))).toBe(
+        product.name,
+      );
+      expect(importedName(String(nitrate[0].speciesId))).toBe(
+        reactant.name,
+      );
+    });
+  });
+
+  describe("EMISSION", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("EMISSION");
+      expect(rx["scaling factor"]).toBe(2.5);
+      expect(rx.products[0].name).toBe(product.name);
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("EMISSION");
+      expect(back.attributes["scaling factor"]?.value).toBe(2.5);
+      expect(importedName(String(back.products[0].speciesId))).toBe(
+        product.name,
+      );
+    });
+  });
+
+  describe("PHOTOLYSIS", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("PHOTOLYSIS");
+      expect(rx["scaling factor"]).toBe(3);
+      expect(rx.reactants[0].name).toBe(reactant.name);
+      expect(rx.products[0].name).toBe(product.name);
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("PHOTOLYSIS");
+      expect(back.attributes["scaling factor"]?.value).toBe(3);
+      expect(importedName(String(back.reactants[0].speciesId))).toBe(
+        reactant.name,
+      );
+      expect(importedName(String(back.products[0].speciesId))).toBe(
+        product.name,
+      );
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("FIRST_ORDER_LOSS", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("FIRST_ORDER_LOSS");
+      expect(rx["scaling factor"]).toBe(1.5);
+      expect(rx.reactants[0].name).toBe(reactant.name);
+      expect(rx.products).toBeUndefined(); // no products supplied → key omitted
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("FIRST_ORDER_LOSS");
+      expect(back.attributes["scaling factor"]?.value).toBe(1.5);
+      expect(importedName(String(back.reactants[0].speciesId))).toBe(
+        reactant.name,
+      );
+      expect(back.products).toHaveLength(0);
+    });
+  });
+
+  describe("TROE", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("TROE");
+      expect(rx.k0_A).toBe(1);
+      expect(rx.k0_C).toBe(3);
+      expect(rx.kinf_A).toBe(4);
+      expect(rx.Fc).toBe(0.5);
+      expect(rx.N).toBe(1);
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("TROE");
+      expect(back.attributes["k0_A"]?.value).toBe(1);
+      expect(back.attributes["Fc"]?.value).toBe(0.5);
+      expect(back.attributes["N"]?.value).toBe(1);
+      expect(importedName(String(back.reactants[0].speciesId))).toBe(
+        reactant.name,
+      );
+    });
+  });
+
+  describe("TUNNELING", () => {
+    it("serializes", () => {
+      const rx = reactionOfType("TUNNELING");
+      expect(rx.A).toBe(1);
+      expect(rx.B).toBe(2);
+      expect(rx.C).toBe(3);
+      expect(rx["gas phase"]).toBe("gas");
+    });
+
+    it("deserializes", () => {
+      const back = importedReactionOfType("TUNNELING");
+      expect(back.attributes["A"]?.value).toBe(1);
+      expect(back.attributes["C"]?.value).toBe(3);
+      expect(importedName(String(back.reactants[0].speciesId))).toBe(
+        reactant.name,
+      );
+    });
+  });
+
+  describe("SURFACE", () => {
+    // it("serializes", () => {
+    //   const rx = reactionOfType("SURFACE");
+    //   expect(rx["reaction probability"]).toBe(0.5);
+    //   // single gas-phase species resolves to its name
+    //   expect(rx["gas-phase species"]).toBe(reactant.name);
+    //   expect(rx["gas-phase products"][0]).toEqual({
+    //     name: product.name,
+    //     coefficient: 2,
+    //   });
+    //   expect(rx["gas phase"]).toBe("gas");
+    // });
+
+    // it("deserializes", () => {
+    //   const back = importedReactionOfType("SURFACE");
+    //   expect(back.attributes["reaction probability"]?.value).toBe(0.5);
+    //   const gasPhaseProducts = back.products.filter(
+    //     (p) => p.branch === "gas-phase",
+    //   );
+    //   expect(importedName(String(gasPhaseProducts[0].speciesId))).toBe(
+    //     product.name,
+    //   );
+    //   // #238: the single gas-phase species is relinked to a species id
+    //   expect(importedName(String(back.gasPhaseSpeciesId))).toBe(reactant.name);
+    // });
   });
 });

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -13,26 +13,12 @@ import {
   serializeMechanismYAML,
 } from "../src/helpers/serialization";
 
-// ─────────────────────────────────────────────────────────────
-// One shared fixture set — species, phases, one reaction per supported type,
-// a mechanism, and a family — used by every test below. The mechanism is
-// serialized once (`serialized`); tests assert against that output.
-//
-// A few cases are deliberately baked into the shared set so they need no
-// separate fixtures:
-//   • ARRHENIUS / PHOTOLYSIS carry a gas phase; TROE / TUNNELING do not
-//     (covers gas-phase present vs omitted).
-//   • the family has an extra phase the mechanism does not reference
-//     (covers phase filtering).
-// ─────────────────────────────────────────────────────────────
-
 /** Build a reaction/attribute bag ({ [key]: { serializationKey, value } }). */
 const attrs = (obj: Record<string, number | string>): Reaction["attributes"] =>
   Object.fromEntries(
     Object.entries(obj).map(([k, v]) => [k, { serializationKey: k, value: v }]),
   );
 
-// ── species (each carries a representative attribute) ─────────
 const molecularWeightSpecies: Species = {
   id: "species-molecular-weight",
   name: "Molecular Weight Species",
@@ -149,6 +135,7 @@ const branchedReaction: Reaction = {
   name: "branched",
   description: null,
   type: "BRANCHED_NO_RO2",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({ X: 1, Y: 2, a0: 3, n: 4 }),
   reactants: [{ speciesId: reactant.id, coefficient: 1 }],
   products: [
@@ -162,6 +149,7 @@ const emissionReaction: Reaction = {
   name: "emission",
   description: null,
   type: "EMISSION",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({ "scaling factor": 2.5 }),
   reactants: [],
   products: [{ speciesId: product.id, coefficient: 1 }],
@@ -183,6 +171,7 @@ const firstOrderLossReaction: Reaction = {
   name: "first order loss",
   description: null,
   type: "FIRST_ORDER_LOSS",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({ "scaling factor": 1.5 }),
   reactants: [{ speciesId: reactant.id, coefficient: 1 }],
   products: [],
@@ -194,6 +183,7 @@ const troeReaction: Reaction = {
   name: "troe",
   description: null,
   type: "TROE",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({
     k0_A: 1,
     k0_B: 2,
@@ -213,6 +203,7 @@ const tunnelingReaction: Reaction = {
   name: "tunneling",
   description: null,
   type: "TUNNELING",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({ A: 1, B: 2, C: 3 }),
   reactants: [{ speciesId: reactant.id, coefficient: 1 }],
   products: [{ speciesId: product.id, coefficient: 1 }],
@@ -223,6 +214,7 @@ const surfaceReaction: Reaction = {
   name: "surface",
   description: null,
   type: "SURFACE",
+  gasPhaseId: gasPhase.id,
   attributes: attrs({ "reaction probability": 0.5 }),
   gasPhaseSpeciesId: reactant.id,
   reactants: [],
@@ -240,7 +232,6 @@ const reactions = [
   surfaceReaction,
 ];
 
-// ── mechanism + family ───────────────────────────────────────
 const mechanism: Mechanism = {
   id: "mechanism",
   name: "Test Mechanism",
@@ -273,17 +264,30 @@ const serialized = serialize();
 const reactionOfType = (type: string): Record<string, any> =>
   serialized.reactions.find((r: any) => r.type === type);
 
+const reactionHasGasPhase = (reaction: Reaction, gasPhaseId: string): boolean => {
+  return reaction.gasPhaseId !== undefined && reaction.gasPhaseId !== null && reaction.gasPhaseId === gasPhaseId;
+}
+
 describe("Mechanism Serialization", () => {
   it("serializes to a JSON string that deserializes to an object", () => {
     const result = serializeMechanismJSON(mechanism, family);
+    const deserialized = deserializeV1Mechanism(result);
     expect(typeof result).toBe("string");
-    expect(typeof deserializeV1Mechanism(result)).toBe("object");
+    expect(typeof deserialized).toBe("object");
+    console.log(deserialized);
+    deserialized?.reactions.forEach((reaction) => {
+      expect(reactionHasGasPhase(reaction, gasPhase.id)).toBe(true);
+    });
   });
 
   it("serializes to a YAML string that deserializes to an object", () => {
     const result = serializeMechanismYAML(mechanism, family);
     expect(typeof result).toBe("string");
-    expect(typeof deserializeV1Mechanism(result)).toBe("object");
+    const deserialized = deserializeV1Mechanism(result);
+    expect(typeof deserialized).toBe("object");
+    deserialized?.reactions.forEach((reaction) => {
+      expect(reactionHasGasPhase(reaction, gasPhase.id)).toBe(true);
+    });
   });
 
   it("serializes a MusicBox (V0) blob object", () => {
@@ -345,6 +349,7 @@ describe("Reaction type serialization", () => {
     const rx = parsed.reactions[0];
     expect(rx.C).toBe(9);
     expect(rx.Ea).toBeUndefined();
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("BRANCHED_NO_RO2", () => {
@@ -355,12 +360,14 @@ describe("Reaction type serialization", () => {
     expect(rx.n).toBe(4);
     expect(rx["alkoxy products"][0].name).toBe(product.name);
     expect(rx["nitrate products"][0].name).toBe(reactant.name);
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("EMISSION", () => {
     const rx = reactionOfType("EMISSION");
     expect(rx["scaling factor"]).toBe(2.5);
     expect(rx.products[0].name).toBe(product.name);
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("PHOTOLYSIS", () => {
@@ -368,6 +375,7 @@ describe("Reaction type serialization", () => {
     expect(rx["scaling factor"]).toBe(3);
     expect(rx.reactants[0].name).toBe(reactant.name);
     expect(rx.products[0].name).toBe(product.name);
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("FIRST_ORDER_LOSS", () => {
@@ -375,6 +383,7 @@ describe("Reaction type serialization", () => {
     expect(rx["scaling factor"]).toBe(1.5);
     expect(rx.reactants[0].name).toBe(reactant.name);
     expect(rx.products).toBeUndefined(); // no products supplied → key omitted
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("TROE", () => {
@@ -384,6 +393,7 @@ describe("Reaction type serialization", () => {
     expect(rx.kinf_A).toBe(4);
     expect(rx.Fc).toBe(0.5);
     expect(rx.N).toBe(1);
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("TUNNELING", () => {
@@ -391,6 +401,7 @@ describe("Reaction type serialization", () => {
     expect(rx.A).toBe(1);
     expect(rx.B).toBe(2);
     expect(rx.C).toBe(3);
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("SURFACE", () => {
@@ -402,15 +413,6 @@ describe("Reaction type serialization", () => {
       name: product.name,
       coefficient: 2,
     });
-  });
-});
-
-describe("Gas phase serialization", () => {
-  it("resolves a reaction's gas phase id to the phase name", () => {
-    expect(reactionOfType("ARRHENIUS")["gas phase"]).toBe("gas");
-  });
-
-  it("omits gas phase when the reaction has none", () => {
-    expect(reactionOfType("TROE")["gas phase"]).toBeUndefined();
+    expect(rx["gas phase"]).toBe("gas");
   });
 });

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -13,6 +13,40 @@ import {
   serializeMechanismYAML,
 } from "../src/helpers/serialization";
 
+// ─────────────────────────────────────────────────────────────
+// One shared fixture set — species, phases, one reaction per supported type,
+// a mechanism, and a family — used by every test below. The mechanism is
+// serialized once (`serialized`); tests assert against that output.
+//
+// A few cases are deliberately baked into the shared set so they need no
+// separate fixtures:
+//   • ARRHENIUS / PHOTOLYSIS carry a gas phase; TROE / TUNNELING do not
+//     (covers gas-phase present vs omitted).
+//   • the family has an extra phase the mechanism does not reference
+//     (covers phase filtering).
+// ─────────────────────────────────────────────────────────────
+
+/** Build a reaction/attribute bag ({ [key]: { serializationKey, value } }). */
+const attrs = (obj: Record<string, number | string>): Reaction["attributes"] =>
+  Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, { serializationKey: k, value: v }]),
+  );
+
+// ── species (each carries a representative attribute) ─────────
+const molecularWeightSpecies: Species = {
+  id: "species-molecular-weight",
+  name: "Molecular Weight Species",
+  description: null,
+  familyId: "",
+  attributes: {
+    "molecular weight [kg mol-1]": {
+      name: "Molecular Weight",
+      serializationKey: "molecular weight [kg mol-1]",
+      value: 1e-2,
+    },
+  },
+};
+
 const mixingRatioSpecies: Species = {
   id: "species-mixing-ratio",
   name: "Mixing Ratio Species",
@@ -41,28 +75,6 @@ const thirdBodySpecies: Species = {
   },
 };
 
-const molecularWeightSpecies: Species = {
-  id: "species-molecular-weight",
-  name: "Molecular Weight Species",
-  description: null,
-  familyId: "",
-  attributes: {
-    "molecular weight [kg mol-1]": {
-      name: "Molecular Weight",
-      serializationKey: "molecular weight [kg mol-1]",
-      value: 1e-2,
-    },
-  },
-};
-
-const plainSpecies: Species = {
-  id: "species-plain",
-  name: "Plain Species",
-  description: null,
-  familyId: "",
-  attributes: {},
-};
-
 const absoluteToleranceSpecies: Species = {
   id: "species-absolute-tolerance",
   name: "Absolute Tolerance Species",
@@ -77,92 +89,32 @@ const absoluteToleranceSpecies: Species = {
   },
 };
 
-const reaction: Reaction = {
-  id: "111-222-333-444-555",
-  name: "Test Reaction",
+const plainSpecies: Species = {
+  id: "species-plain",
+  name: "Plain Species",
   description: null,
-  type: "PHOTOLYSIS",
-  reactants: [
-    {
-      speciesId: mixingRatioSpecies.id,
-      coefficient: 1,
-    },
-    {
-      speciesId: absoluteToleranceSpecies.id,
-      coefficient: 1,
-    },
-    {
-      speciesId: "not-real-id",
-      coefficient: 1,
-    },
-  ],
-  products: [
-    {
-      speciesId: thirdBodySpecies.id,
-      coefficient: 1,
-    },
-    {
-      speciesId: "not-real-id",
-      coefficient: 1,
-    },
-  ],
-  attributes: {
-    "attribute [mol]": {
-      name: "Attribute",
-      value: 1.0,
-      serializationKey: "attribute [mol]",
-    },
-    "another attribute": {
-      name: "another attribute",
-      serializationKey: "another attribute",
-      value: 1.0,
-    },
-  },
-};
-
-const branchedReaction: Reaction = {
-  id: "555-444-333-222-111",
-  name: "",
-  description: null,
-  type: "BRANCHED_NO_RO2",
-  reactants: [
-    {
-      speciesId: molecularWeightSpecies.id,
-      coefficient: 1,
-    },
-  ],
-  products: [
-    {
-      speciesId: plainSpecies.id,
-      coefficient: 1,
-      branch: "alkoxy",
-    },
-    {
-      speciesId: molecularWeightSpecies.id,
-      coefficient: 1,
-      branch: "nitrate",
-    },
-  ],
+  familyId: "",
   attributes: {},
 };
 
-// NOTE: SURFACE export is covered in "Reaction type serialization" below. It is
-// kept out of these round-trip fixtures because import does not yet relink its
-// gas-phase species (tracked in #238); the editor UI for it is #237.
-
-const allSpecies = [
+const species = [
+  molecularWeightSpecies,
   mixingRatioSpecies,
   thirdBodySpecies,
-  molecularWeightSpecies,
-  plainSpecies,
   absoluteToleranceSpecies,
+  plainSpecies,
 ];
 
-const mainGasPhase: Phase = {
-  id: "phase-gas-main",
+// common reactant/product picks, for readable reaction definitions
+const reactant = molecularWeightSpecies;
+const product = plainSpecies;
+
+// ── phases ───────────────────────────────────────────────────
+const gasPhase: Phase = {
+  id: "phase-gas",
   name: "gas",
   description: null,
-  speciesIds: allSpecies.map((s) => s.id),
+  speciesIds: species.map((s) => s.id),
 };
 
 const aerosolPhase: Phase = {
@@ -172,275 +124,261 @@ const aerosolPhase: Phase = {
   speciesIds: [molecularWeightSpecies.id, plainSpecies.id],
 };
 
+// present in the family but NOT referenced by the mechanism (filtering case)
+const unreferencedPhase: Phase = {
+  id: "phase-unreferenced",
+  name: "unreferenced",
+  description: null,
+  speciesIds: [plainSpecies.id],
+};
+
+// ── reactions (one per supported type) ───────────────────────
+const arrheniusReaction: Reaction = {
+  id: "reaction-arrhenius",
+  name: "arrhenius",
+  description: null,
+  type: "ARRHENIUS",
+  gasPhaseId: gasPhase.id,
+  attributes: attrs({ A: 1, B: 2, Ea: 3, D: 4, E: 5 }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [{ speciesId: product.id, coefficient: 2 }],
+};
+
+const branchedReaction: Reaction = {
+  id: "reaction-branched",
+  name: "branched",
+  description: null,
+  type: "BRANCHED_NO_RO2",
+  attributes: attrs({ X: 1, Y: 2, a0: 3, n: 4 }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [
+    { speciesId: product.id, coefficient: 1, branch: "alkoxy" },
+    { speciesId: reactant.id, coefficient: 1, branch: "nitrate" },
+  ],
+};
+
+const emissionReaction: Reaction = {
+  id: "reaction-emission",
+  name: "emission",
+  description: null,
+  type: "EMISSION",
+  attributes: attrs({ "scaling factor": 2.5 }),
+  reactants: [],
+  products: [{ speciesId: product.id, coefficient: 1 }],
+};
+
+const photolysisReaction: Reaction = {
+  id: "reaction-photolysis",
+  name: "photolysis",
+  description: null,
+  type: "PHOTOLYSIS",
+  gasPhaseId: gasPhase.id,
+  attributes: attrs({ "scaling factor": 3 }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [{ speciesId: product.id, coefficient: 1 }],
+};
+
+const firstOrderLossReaction: Reaction = {
+  id: "reaction-first-order-loss",
+  name: "first order loss",
+  description: null,
+  type: "FIRST_ORDER_LOSS",
+  attributes: attrs({ "scaling factor": 1.5 }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [],
+};
+
+// no gas phase — exercises the "gas phase omitted" case
+const troeReaction: Reaction = {
+  id: "reaction-troe",
+  name: "troe",
+  description: null,
+  type: "TROE",
+  attributes: attrs({
+    k0_A: 1,
+    k0_B: 2,
+    k0_C: 3,
+    kinf_A: 4,
+    kinf_B: 5,
+    kinf_C: 6,
+    Fc: 0.5,
+    N: 1,
+  }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [{ speciesId: product.id, coefficient: 1 }],
+};
+
+const tunnelingReaction: Reaction = {
+  id: "reaction-tunneling",
+  name: "tunneling",
+  description: null,
+  type: "TUNNELING",
+  attributes: attrs({ A: 1, B: 2, C: 3 }),
+  reactants: [{ speciesId: reactant.id, coefficient: 1 }],
+  products: [{ speciesId: product.id, coefficient: 1 }],
+};
+
+const surfaceReaction: Reaction = {
+  id: "reaction-surface",
+  name: "surface",
+  description: null,
+  type: "SURFACE",
+  attributes: attrs({ "reaction probability": 0.5 }),
+  gasPhaseSpeciesId: reactant.id,
+  reactants: [],
+  products: [{ speciesId: product.id, coefficient: 2, branch: "gas-phase" }],
+};
+
+const reactions = [
+  arrheniusReaction,
+  branchedReaction,
+  emissionReaction,
+  photolysisReaction,
+  firstOrderLossReaction,
+  troeReaction,
+  tunnelingReaction,
+  surfaceReaction,
+];
+
+// ── mechanism + family ───────────────────────────────────────
 const mechanism: Mechanism = {
-  id: "",
+  id: "mechanism",
   name: "Test Mechanism",
   description: null,
-  phaseIds: [mainGasPhase.id, aerosolPhase.id],
-  familyId: "1234",
-  speciesIds: allSpecies.map((s) => s.id),
-  reactionIds: [reaction.id, branchedReaction.id],
+  familyId: "family",
+  speciesIds: species.map((s) => s.id),
+  reactionIds: reactions.map((r) => r.id),
+  // note: unreferencedPhase intentionally omitted
+  phaseIds: [gasPhase.id, aerosolPhase.id],
 };
 
 const family: Family = {
-  id: "1234",
+  id: "family",
   name: "Test Family",
   description: "",
-  mechanisms: [],
-  species: allSpecies,
-  reactions: [reaction, branchedReaction],
-  phases: [mainGasPhase, aerosolPhase],
   owner: null,
+  mechanisms: [],
+  species,
+  reactions,
+  phases: [gasPhase, aerosolPhase, unreferencedPhase],
 };
 
+/** Serialize the shared mechanism to JSON and parse it back to an object. */
+const serialize = (m = mechanism, f = family): Record<string, any> =>
+  JSON.parse(serializeMechanismJSON(m, f));
+
+const serialized = serialize();
+
+/** Find the serialized reaction of a given type. */
+const reactionOfType = (type: string): Record<string, any> =>
+  serialized.reactions.find((r: any) => r.type === type);
+
 describe("Mechanism Serialization", () => {
-  describe("JSON Serialization", () => {
-    it("Gives a string", () => {
-      const result = serializeMechanismJSON(mechanism, family);
-      expect(typeof result).toBe("string");
-      const reversedSerialization = deserializeV1Mechanism(result);
-      expect(typeof reversedSerialization).toBe("object");
-    });
+  it("serializes to a JSON string that deserializes to an object", () => {
+    const result = serializeMechanismJSON(mechanism, family);
+    expect(typeof result).toBe("string");
+    expect(typeof deserializeV1Mechanism(result)).toBe("object");
   });
 
-  describe("YAML Serialization", () => {
-    it("Gives a string", () => {
-      const result = serializeMechanismYAML(mechanism, family);
-      expect(typeof result).toBe("string");
-      const reversedSerialization = deserializeV1Mechanism(result);
-      expect(typeof reversedSerialization).toBe("object");
-    });
+  it("serializes to a YAML string that deserializes to an object", () => {
+    const result = serializeMechanismYAML(mechanism, family);
+    expect(typeof result).toBe("string");
+    expect(typeof deserializeV1Mechanism(result)).toBe("object");
   });
 
-  describe("V0 Serialization", () => {
-    it("Gives a resulting blob object", () => {
-      const result = serializeMechanismMusicBox(mechanism, family);
-      expect(typeof result).toBe("object");
-    });
-  });
-
-  describe("Phase serialization", () => {
-    it("serializes a mechanism's phases with their member species", () => {
-      const parsed = JSON.parse(serializeMechanismJSON(mechanism, family));
-      const phaseNames = parsed.phases.map((p: any) => p.name);
-      expect(phaseNames).toContain("gas");
-      expect(phaseNames).toContain("aerosol");
-
-      const gas = parsed.phases.find((p: any) => p.name === "gas");
-      // species ids are resolved to names, one entry per member species
-      expect(gas.species.map((s: any) => s.name).sort()).toEqual(
-        allSpecies.map((s) => s.name).sort(),
-      );
-
-      const aerosol = parsed.phases.find((p: any) => p.name === "aerosol");
-      expect(aerosol.species.map((s: any) => s.name).sort()).toEqual(
-        ["Molecular Weight Species", "Plain Species"].sort(),
-      );
-    });
-
-    it("only includes phases referenced by the mechanism", () => {
-      const otherPhase: Phase = {
-        id: "phase-unreferenced",
-        name: "unreferenced",
-        description: null,
-        speciesIds: [plainSpecies.id],
-      };
-      const familyWithExtra: Family = {
-        ...family,
-        phases: [...family.phases, otherPhase],
-      };
-      const parsed = JSON.parse(
-        serializeMechanismJSON(mechanism, familyWithExtra),
-      );
-      const phaseNames = parsed.phases.map((p: any) => p.name);
-      expect(phaseNames).not.toContain("unreferenced");
-    });
+  it("serializes a MusicBox (V0) blob object", () => {
+    const result = serializeMechanismMusicBox(mechanism, family);
+    expect(typeof result).toBe("object");
   });
 });
 
-// ── per-reaction-type serialization ──────────────────────────
-// Each supported reaction type is exported through the musica adapter and its
-// V1 wire shape asserted. SURFACE is intentionally absent (no adapter — #237).
+describe("Phase serialization", () => {
+  it("serializes referenced phases with their member species", () => {
+    const phaseNames = serialized.phases.map((p: any) => p.name);
+    expect(phaseNames).toContain("gas");
+    expect(phaseNames).toContain("aerosol");
 
-const speciesA: Species = {
-  id: "species-a",
-  name: "A",
-  description: null,
-  familyId: "",
-  attributes: {},
-};
-const speciesB: Species = {
-  id: "species-b",
-  name: "B",
-  description: null,
-  familyId: "",
-  attributes: {},
-};
+    // species ids are resolved to names, one entry per member species
+    const gas = serialized.phases.find((p: any) => p.name === "gas");
+    expect(gas.species.map((s: any) => s.name).sort()).toEqual(
+      species.map((s) => s.name).sort(),
+    );
 
-const gasPhase: Phase = {
-  id: "phase-gas",
-  name: "gas",
-  description: null,
-  speciesIds: [speciesA.id, speciesB.id],
-};
+    const aerosol = serialized.phases.find((p: any) => p.name === "aerosol");
+    expect(aerosol.species.map((s: any) => s.name).sort()).toEqual(
+      [molecularWeightSpecies.name, plainSpecies.name].sort(),
+    );
+  });
 
-/** Build a reaction attribute bag ({ [key]: { serializationKey, value } }). */
-const attrs = (obj: Record<string, number | string>): Reaction["attributes"] =>
-  Object.fromEntries(
-    Object.entries(obj).map(([k, v]) => [k, { serializationKey: k, value: v }]),
-  );
-
-/** Serialize a single reaction and return the parsed V1 reaction object. */
-const serializeReaction = (reaction: Reaction): Record<string, any> => {
-  const fam: Family = {
-    id: "family",
-    name: "Family",
-    description: "",
-    mechanisms: [],
-    species: [speciesA, speciesB],
-    reactions: [reaction],
-    phases: [gasPhase],
-    owner: null,
-  };
-  const mech: Mechanism = {
-    id: "mechanism",
-    name: "Mechanism",
-    description: null,
-    familyId: "family",
-    speciesIds: [speciesA.id, speciesB.id],
-    reactionIds: [reaction.id],
-    phaseIds: [gasPhase.id],
-  };
-  const parsed = JSON.parse(serializeMechanismJSON(mech, fam));
-  return parsed.reactions[0];
-};
+  it("omits phases the mechanism does not reference", () => {
+    const phaseNames = serialized.phases.map((p: any) => p.name);
+    expect(phaseNames).not.toContain("unreferenced");
+  });
+});
 
 describe("Reaction type serialization", () => {
   it("ARRHENIUS", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "arr",
-      description: null,
-      type: "ARRHENIUS",
-      attributes: attrs({ A: 1, B: 2, Ea: 3, D: 4, E: 5 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 2 }],
-    });
-    expect(rx.type).toBe("ARRHENIUS");
+    const rx = reactionOfType("ARRHENIUS");
     expect(rx.A).toBe(1);
     expect(rx.B).toBe(2);
     expect(rx.Ea).toBe(3); // Ea present, so C omitted
     expect(rx.C).toBeUndefined();
     expect(rx.D).toBe(4);
     expect(rx.E).toBe(5);
-    expect(rx.reactants[0].name).toBe("A");
-    expect(rx.products[0]).toEqual({ name: "B", coefficient: 2 });
+    expect(rx.reactants[0].name).toBe(reactant.name);
+    expect(rx.products[0]).toEqual({ name: product.name, coefficient: 2 });
+    expect(rx["gas phase"]).toBe("gas");
   });
 
   it("ARRHENIUS without Ea falls back to C", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "arr",
-      description: null,
-      type: "ARRHENIUS",
+    // the one case that needs a reaction variant: C and Ea are mutually
+    // exclusive, so the shared (Ea) reaction cannot also cover the C branch.
+    const cReaction: Reaction = {
+      ...arrheniusReaction,
+      id: "reaction-arrhenius-c",
       attributes: attrs({ A: 1, C: 9 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
-    });
+    };
+    const parsed = serialize(
+      { ...mechanism, reactionIds: [cReaction.id] },
+      { ...family, reactions: [cReaction] },
+    );
+    const rx = parsed.reactions[0];
     expect(rx.C).toBe(9);
     expect(rx.Ea).toBeUndefined();
   });
 
   it("BRANCHED_NO_RO2", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "br",
-      description: null,
-      type: "BRANCHED_NO_RO2",
-      attributes: attrs({ X: 1, Y: 2, a0: 3, n: 4 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [
-        { speciesId: speciesB.id, coefficient: 1, branch: "nitrate" },
-        { speciesId: speciesA.id, coefficient: 1, branch: "alkoxy" },
-      ],
-    });
-    expect(rx.type).toBe("BRANCHED_NO_RO2");
+    const rx = reactionOfType("BRANCHED_NO_RO2");
     expect(rx.X).toBe(1);
     expect(rx.Y).toBe(2);
     expect(rx.a0).toBe(3);
     expect(rx.n).toBe(4);
-    expect(rx["nitrate products"][0].name).toBe("B");
-    expect(rx["alkoxy products"][0].name).toBe("A");
+    expect(rx["alkoxy products"][0].name).toBe(product.name);
+    expect(rx["nitrate products"][0].name).toBe(reactant.name);
   });
 
   it("EMISSION", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "em",
-      description: null,
-      type: "EMISSION",
-      attributes: attrs({ "scaling factor": 2.5 }),
-      reactants: [],
-      products: [{ speciesId: speciesA.id, coefficient: 1 }],
-    });
-    expect(rx.type).toBe("EMISSION");
+    const rx = reactionOfType("EMISSION");
     expect(rx["scaling factor"]).toBe(2.5);
-    expect(rx.products[0].name).toBe("A");
+    expect(rx.products[0].name).toBe(product.name);
   });
 
   it("PHOTOLYSIS", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "photo",
-      description: null,
-      type: "PHOTOLYSIS",
-      attributes: attrs({ "scaling factor": 3 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
-    });
-    expect(rx.type).toBe("PHOTOLYSIS");
+    const rx = reactionOfType("PHOTOLYSIS");
     expect(rx["scaling factor"]).toBe(3);
-    expect(rx.reactants[0].name).toBe("A");
-    expect(rx.products[0].name).toBe("B");
+    expect(rx.reactants[0].name).toBe(reactant.name);
+    expect(rx.products[0].name).toBe(product.name);
   });
 
   it("FIRST_ORDER_LOSS", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "fol",
-      description: null,
-      type: "FIRST_ORDER_LOSS",
-      attributes: attrs({ "scaling factor": 1.5 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [],
-    });
-    expect(rx.type).toBe("FIRST_ORDER_LOSS");
+    const rx = reactionOfType("FIRST_ORDER_LOSS");
     expect(rx["scaling factor"]).toBe(1.5);
-    expect(rx.reactants[0].name).toBe("A");
-    // no products supplied → key omitted
-    expect(rx.products).toBeUndefined();
+    expect(rx.reactants[0].name).toBe(reactant.name);
+    expect(rx.products).toBeUndefined(); // no products supplied → key omitted
   });
 
   it("TROE", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "troe",
-      description: null,
-      type: "TROE",
-      attributes: attrs({
-        k0_A: 1,
-        k0_B: 2,
-        k0_C: 3,
-        kinf_A: 4,
-        kinf_B: 5,
-        kinf_C: 6,
-        Fc: 0.5,
-        N: 1,
-      }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
-    });
-    expect(rx.type).toBe("TROE");
+    const rx = reactionOfType("TROE");
     expect(rx.k0_A).toBe(1);
     expect(rx.k0_C).toBe(3);
     expect(rx.kinf_A).toBe(4);
@@ -449,63 +387,30 @@ describe("Reaction type serialization", () => {
   });
 
   it("TUNNELING", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "tun",
-      description: null,
-      type: "TUNNELING",
-      attributes: attrs({ A: 1, B: 2, C: 3 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
-    });
-    expect(rx.type).toBe("TUNNELING");
+    const rx = reactionOfType("TUNNELING");
     expect(rx.A).toBe(1);
     expect(rx.B).toBe(2);
     expect(rx.C).toBe(3);
   });
 
   it("SURFACE", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "surf",
-      description: null,
-      type: "SURFACE",
-      attributes: attrs({ "reaction probability": 0.5 }),
-      gasPhaseSpeciesId: speciesA.id,
-      reactants: [],
-      products: [{ speciesId: speciesB.id, coefficient: 2, branch: "gas-phase" }],
-    });
-    expect(rx.type).toBe("SURFACE");
+    const rx = reactionOfType("SURFACE");
     expect(rx["reaction probability"]).toBe(0.5);
     // single gas-phase species resolves to its name
-    expect(rx["gas-phase species"]).toBe("A");
-    expect(rx["gas-phase products"][0]).toEqual({ name: "B", coefficient: 2 });
-  });
-
-  it("resolves a reaction's gas phase id to the phase name", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "arr-gas",
-      description: null,
-      type: "ARRHENIUS",
-      attributes: attrs({ A: 1 }),
-      gasPhaseId: gasPhase.id,
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
+    expect(rx["gas-phase species"]).toBe(reactant.name);
+    expect(rx["gas-phase products"][0]).toEqual({
+      name: product.name,
+      coefficient: 2,
     });
-    expect(rx["gas phase"]).toBe("gas");
+  });
+});
+
+describe("Gas phase serialization", () => {
+  it("resolves a reaction's gas phase id to the phase name", () => {
+    expect(reactionOfType("ARRHENIUS")["gas phase"]).toBe("gas");
   });
 
   it("omits gas phase when the reaction has none", () => {
-    const rx = serializeReaction({
-      id: "r",
-      name: "arr-nogas",
-      description: null,
-      type: "ARRHENIUS",
-      attributes: attrs({ A: 1 }),
-      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
-      products: [{ speciesId: speciesB.id, coefficient: 1 }],
-    });
-    expect(rx["gas phase"]).toBeUndefined();
+    expect(reactionOfType("TROE")["gas phase"]).toBeUndefined();
   });
 });

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -275,8 +275,10 @@ describe("Mechanism Serialization", () => {
     expect(typeof result).toBe("string");
     expect(typeof deserialized).toBe("object");
     console.log(deserialized);
+    const deserializedGasPhase = deserialized?.phases.find((p) => p.name === "gas");
+    expect(deserializedGasPhase).toBeDefined();
     deserialized?.reactions.forEach((reaction) => {
-      expect(reactionHasGasPhase(reaction, gasPhase.id)).toBe(true);
+      expect(reactionHasGasPhase(reaction, deserializedGasPhase.id)).toBe(true);
     });
   });
 
@@ -285,8 +287,10 @@ describe("Mechanism Serialization", () => {
     expect(typeof result).toBe("string");
     const deserialized = deserializeV1Mechanism(result);
     expect(typeof deserialized).toBe("object");
+    const deserializedGasPhase = deserialized?.phases.find((p) => p.name === "gas");
+    expect(deserializedGasPhase).toBeDefined();
     deserialized?.reactions.forEach((reaction) => {
-      expect(reactionHasGasPhase(reaction, gasPhase.id)).toBe(true);
+      expect(reactionHasGasPhase(reaction, deserializedGasPhase.id)).toBe(true);
     });
   });
 

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -376,6 +376,9 @@ describe("Reaction type serialization and deserialization", () => {
         product.name,
       );
       expect(back.products[0].coefficient).toBe(2);
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
     });
 
     it("serializes with C when Ea is absent", () => {
@@ -420,6 +423,9 @@ describe("Reaction type serialization and deserialization", () => {
       expect(importedName(String(nitrate[0].speciesId))).toBe(
         reactant.name,
       );
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
     });
   });
 
@@ -436,6 +442,9 @@ describe("Reaction type serialization and deserialization", () => {
       expect(back.attributes["scaling factor"]?.value).toBe(2.5);
       expect(importedName(String(back.products[0].speciesId))).toBe(
         product.name,
+      );
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
       );
     });
   });
@@ -480,6 +489,9 @@ describe("Reaction type serialization and deserialization", () => {
         reactant.name,
       );
       expect(back.products).toHaveLength(0);
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
     });
   });
 
@@ -502,6 +514,9 @@ describe("Reaction type serialization and deserialization", () => {
       expect(importedName(String(back.reactants[0].speciesId))).toBe(
         reactant.name,
       );
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
     });
   });
 
@@ -521,33 +536,38 @@ describe("Reaction type serialization and deserialization", () => {
       expect(importedName(String(back.reactants[0].speciesId))).toBe(
         reactant.name,
       );
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
     });
   });
 
   describe("SURFACE", () => {
-    // it("serializes", () => {
-    //   const rx = reactionOfType("SURFACE");
-    //   expect(rx["reaction probability"]).toBe(0.5);
-    //   // single gas-phase species resolves to its name
-    //   expect(rx["gas-phase species"]).toBe(reactant.name);
-    //   expect(rx["gas-phase products"][0]).toEqual({
-    //     name: product.name,
-    //     coefficient: 2,
-    //   });
-    //   expect(rx["gas phase"]).toBe("gas");
-    // });
+    it("serializes", () => {
+      const rx = reactionOfType("SURFACE");
+      expect(rx["reaction probability"]).toBe(0.5);
+      // single gas-phase species resolves to its name
+      expect(rx["gas-phase species"]).toBe(reactant.name);
+      expect(rx["gas-phase products"][0]).toEqual({
+        name: product.name,
+        coefficient: 2,
+      });
+      expect(rx["gas phase"]).toBe("gas");
+    });
 
-    // it("deserializes", () => {
-    //   const back = importedReactionOfType("SURFACE");
-    //   expect(back.attributes["reaction probability"]?.value).toBe(0.5);
-    //   const gasPhaseProducts = back.products.filter(
-    //     (p) => p.branch === "gas-phase",
-    //   );
-    //   expect(importedName(String(gasPhaseProducts[0].speciesId))).toBe(
-    //     product.name,
-    //   );
-    //   // #238: the single gas-phase species is relinked to a species id
-    //   expect(importedName(String(back.gasPhaseSpeciesId))).toBe(reactant.name);
-    // });
+    it("deserializes", () => {
+      const back = importedReactionOfType("SURFACE");
+      expect(back.attributes["reaction probability"]?.value).toBe(0.5);
+      const gasPhaseProducts = back.products.filter(
+        (p) => p.branch === "gas-phase",
+      );
+      expect(importedName(String(gasPhaseProducts[0].speciesId))).toBe(
+        product.name,
+      );
+      expect(importedName(String(back.gasPhaseSpeciesId))).toBe(reactant.name);
+      expect(reactionHasGasPhase(back, importedGasPhase()!.id)).toBe(
+        true,
+      );
+    });
   });
 });

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -347,6 +347,69 @@ describe("Phase serialization", () => {
   });
 });
 
+describe("Species serialization", () => {
+  beforeAll(initFixtures);
+
+  it("serializes species attributes to their v1 wire keys", () => {
+    const byName = (name: string) =>
+      serialized.species.find((s: any) => s.name === name);
+
+    expect(byName(molecularWeightSpecies.name)["molecular weight [kg mol-1]"]).toBe(
+      0.01,
+    );
+    expect(
+      byName(mixingRatioSpecies.name)["constant mixing ratio [mol mol-1]"],
+    ).toBe(0.01);
+    // string "true" is coerced to a boolean
+    expect(byName(thirdBodySpecies.name)["is third body"]).toBe(true);
+    // non-first-class properties are emitted with musica's `__` prefix
+    expect(byName(absoluteToleranceSpecies.name)["__absolute tolerance"]).toBe(
+      1e-9,
+    );
+    // a species with no attributes serializes to just its name
+    expect(Object.keys(byName(plainSpecies.name))).toEqual(["name"]);
+  });
+
+  it("deserializes species attributes back to the model", () => {
+    const byName = (name: string) =>
+      imported.species.find((s) => s.name === name)!;
+
+    expect(
+      byName(molecularWeightSpecies.name).attributes["molecular weight [kg mol-1]"]
+        ?.value,
+    ).toBe(0.01);
+    expect(
+      byName(mixingRatioSpecies.name).attributes[
+        "constant mixing ratio [mol mol-1]"
+      ]?.value,
+    ).toBe(0.01);
+    // booleans are normalized back to a string (SpeciesAttribute.value is number | string)
+    expect(byName(thirdBodySpecies.name).attributes["is third body"]?.value).toBe(
+      "true",
+    );
+    // the `__` prefix is stripped so the key matches the chemistry-cafe serializationKey
+    expect(
+      byName(absoluteToleranceSpecies.name).attributes["absolute tolerance"]
+        ?.value,
+    ).toBe(1e-9);
+  });
+
+  it("omits 'is third body' when the species is not a third body", () => {
+    const notThirdBody: Species = {
+      ...thirdBodySpecies,
+      id: "species-not-third-body",
+      attributes: {
+        "is third body": { serializationKey: "is third body", value: "false" },
+      },
+    };
+    const parsed = serialize(
+      { ...mechanism, speciesIds: [notThirdBody.id], reactionIds: [], phaseIds: [] },
+      { ...family, species: [notThirdBody], reactions: [], phases: [] },
+    );
+    expect(parsed.species[0]["is third body"]).toBeUndefined();
+  });
+});
+
 describe("Reaction type serialization and deserialization", () => {
   beforeAll(initFixtures);
 

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -158,11 +158,25 @@ const allSpecies = [
   absoluteToleranceSpecies,
 ];
 
+const mainGasPhase: Phase = {
+  id: "phase-gas-main",
+  name: "gas",
+  description: null,
+  speciesIds: allSpecies.map((s) => s.id),
+};
+
+const aerosolPhase: Phase = {
+  id: "phase-aerosol",
+  name: "aerosol",
+  description: null,
+  speciesIds: [molecularWeightSpecies.id, plainSpecies.id],
+};
+
 const mechanism: Mechanism = {
   id: "",
   name: "Test Mechanism",
   description: null,
-  phaseIds: [],
+  phaseIds: [mainGasPhase.id, aerosolPhase.id],
   familyId: "1234",
   speciesIds: allSpecies.map((s) => s.id),
   reactionIds: [reaction.id, branchedReaction.id],
@@ -175,7 +189,7 @@ const family: Family = {
   mechanisms: [],
   species: allSpecies,
   reactions: [reaction, branchedReaction],
-  phases: [],
+  phases: [mainGasPhase, aerosolPhase],
   owner: null,
 };
 
@@ -202,6 +216,44 @@ describe("Mechanism Serialization", () => {
     it("Gives a resulting blob object", () => {
       const result = serializeMechanismMusicBox(mechanism, family);
       expect(typeof result).toBe("object");
+    });
+  });
+
+  describe("Phase serialization", () => {
+    it("serializes a mechanism's phases with their member species", () => {
+      const parsed = JSON.parse(serializeMechanismJSON(mechanism, family));
+      const phaseNames = parsed.phases.map((p: any) => p.name);
+      expect(phaseNames).toContain("gas");
+      expect(phaseNames).toContain("aerosol");
+
+      const gas = parsed.phases.find((p: any) => p.name === "gas");
+      // species ids are resolved to names, one entry per member species
+      expect(gas.species.map((s: any) => s.name).sort()).toEqual(
+        allSpecies.map((s) => s.name).sort(),
+      );
+
+      const aerosol = parsed.phases.find((p: any) => p.name === "aerosol");
+      expect(aerosol.species.map((s: any) => s.name).sort()).toEqual(
+        ["Molecular Weight Species", "Plain Species"].sort(),
+      );
+    });
+
+    it("only includes phases referenced by the mechanism", () => {
+      const otherPhase: Phase = {
+        id: "phase-unreferenced",
+        name: "unreferenced",
+        description: null,
+        speciesIds: [plainSpecies.id],
+      };
+      const familyWithExtra: Family = {
+        ...family,
+        phases: [...family.phases, otherPhase],
+      };
+      const parsed = JSON.parse(
+        serializeMechanismJSON(mechanism, familyWithExtra),
+      );
+      const phaseNames = parsed.phases.map((p: any) => p.name);
+      expect(phaseNames).not.toContain("unreferenced");
     });
   });
 });

--- a/frontend/test/serialization.test.tsx
+++ b/frontend/test/serialization.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   Family,
   Mechanism,
+  Phase,
   Reaction,
   Species,
 } from "../src/types/chemistryModels";
@@ -224,6 +225,13 @@ const speciesB: Species = {
   attributes: {},
 };
 
+const gasPhase: Phase = {
+  id: "phase-gas",
+  name: "gas",
+  description: null,
+  speciesIds: [speciesA.id, speciesB.id],
+};
+
 /** Build a reaction attribute bag ({ [key]: { serializationKey, value } }). */
 const attrs = (obj: Record<string, number | string>): Reaction["attributes"] =>
   Object.fromEntries(
@@ -239,7 +247,7 @@ const serializeReaction = (reaction: Reaction): Record<string, any> => {
     mechanisms: [],
     species: [speciesA, speciesB],
     reactions: [reaction],
-    phases: [],
+    phases: [gasPhase],
     owner: null,
   };
   const mech: Mechanism = {
@@ -249,7 +257,7 @@ const serializeReaction = (reaction: Reaction): Record<string, any> => {
     familyId: "family",
     speciesIds: [speciesA.id, speciesB.id],
     reactionIds: [reaction.id],
-    phaseIds: [],
+    phaseIds: [gasPhase.id],
   };
   const parsed = JSON.parse(serializeMechanismJSON(mech, fam));
   return parsed.reactions[0];
@@ -420,5 +428,32 @@ describe("Reaction type serialization", () => {
     // single gas-phase species resolves to its name
     expect(rx["gas-phase species"]).toBe("A");
     expect(rx["gas-phase products"][0]).toEqual({ name: "B", coefficient: 2 });
+  });
+
+  it("resolves a reaction's gas phase id to the phase name", () => {
+    const rx = serializeReaction({
+      id: "r",
+      name: "arr-gas",
+      description: null,
+      type: "ARRHENIUS",
+      attributes: attrs({ A: 1 }),
+      gasPhaseId: gasPhase.id,
+      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
+      products: [{ speciesId: speciesB.id, coefficient: 1 }],
+    });
+    expect(rx["gas phase"]).toBe("gas");
+  });
+
+  it("omits gas phase when the reaction has none", () => {
+    const rx = serializeReaction({
+      id: "r",
+      name: "arr-nogas",
+      description: null,
+      type: "ARRHENIUS",
+      attributes: attrs({ A: 1 }),
+      reactants: [{ speciesId: speciesA.id, coefficient: 1 }],
+      products: [{ speciesId: speciesB.id, coefficient: 1 }],
+    });
+    expect(rx["gas phase"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #238 

- relinks the gas phase for all reactions on deserialization
- refactors the tests so that we test every reaction variant, species variant